### PR TITLE
Fix markdown linting issues

### DIFF
--- a/docs/K_ARY_INVESTIGATION.md
+++ b/docs/K_ARY_INVESTIGATION.md
@@ -226,9 +226,12 @@ When a node would have k+1 children, need splitting strategy:
 4. **Add splitting logic**: When children exceed k, split or promote
 
 ### Performance Optimization Opportunity
-- **SmallVec consideration**: TwoThreeHeap uses `Vec<Option<NonNull<...>>>` for children (2-3 typical)
+
+- **SmallVec consideration**: TwoThreeHeap uses
+  `Vec<Option<NonNull<...>>>` for children (2-3 typical)
 - Nodes usually have 2-3 children, rarely more
-- `SmallVec<[Option<NonNull<Node>>; 3]>` could eliminate allocations for typical nodes
+- `SmallVec<[Option<NonNull<Node>>; 3]>` could eliminate
+  allocations for typical nodes
 - Trade-off: larger node size vs. allocation overhead
 - Recommendation: Benchmark both approaches before optimizing
 
@@ -505,48 +508,72 @@ unsafe fn maintain_structure(&mut self, node: NonNull<Node<T, P>>) {
 ### Key Discovery: Most Heaps are Already Multi-Way Trees
 
 After analyzing all heap implementations, we found:
-- **PairingHeap, FibonacciHeap, RankPairingHeap**: Already use unbounded multi-way trees with child/sibling pointers
-- **BinomialHeap, SkewBinomialHeap**: Use child/sibling linked lists (effectively multi-way, not binary)
-- **TwoThreeHeap**: The ONLY heap with fixed arity (2-3 children per node)
+
+- **PairingHeap, FibonacciHeap, RankPairingHeap**: Already use
+  unbounded multi-way trees with child/sibling pointers
+- **BinomialHeap, SkewBinomialHeap**: Use child/sibling linked
+  lists (effectively multi-way, not binary)
+- **TwoThreeHeap**: The ONLY heap with fixed arity (2-3 children
+  per node)
 
 ### K-Ary Parametrization Assessment
 
-**Reality Check**: The investigation document's assumption that heaps are "binary" is **incorrect**. Most heaps are already multi-way trees. The relevant question is whether to constrain them with a maximum degree K.
+**Reality Check**: The investigation document's assumption that
+heaps are "binary" is **incorrect**. Most heaps are already
+multi-way trees. The relevant question is whether to constrain
+them with a maximum degree K.
 
 #### Option 1: Const Generics for Two-Three Heap
+
 - **Feasibility**: ✅ Highly feasible
-- **Why**: Two-Three heap already uses `Vec<Option<NonNull<Node>>>` for children
-- **Implementation**: Add `const K: usize` parameter, constrain `children` vector length
+- **Why**: Two-Three heap already uses
+  `Vec<Option<NonNull<Node>>>` for children
+- **Implementation**: Add `const K: usize` parameter, constrain
+  `children` vector length
 - **Impact on Original Binary**: N/A (it's not binary)
 - **Recommendation**: **Best candidate for k-ary generalization**
 
 #### Option 2: Add Runtime K Constraint to Multi-Way Heaps
+
 - **Feasibility**: ⚠️ Complex, questionable benefit
-- **Why**: Would require adding splitting logic to heaps that deliberately allow unbounded children
-- **Trade-off**: Randomly constraining multi-way heaps goes against their design philosophy
+- **Why**: Would require adding splitting logic to heaps that
+  deliberately allow unbounded children
+- **Trade-off**: Randomly constraining multi-way heaps goes
+  against their design philosophy
 - **Impact**: Would degrade original implementations
 - **Recommendation**: **Not recommended**
 
 ### Conclusion
 
-The investigation reveals that **most heaps are already "k-ary" with k=∞**. The real opportunity is:
-1. **Generalize TwoThreeHeap** to support arbitrary k (not just 2-3)
+The investigation reveals that **most heaps are already "k-ary"
+with k=∞**. The real opportunity is:
+
+1. **Generalize TwoThreeHeap** to support arbitrary k (not just
+   2-3)
 2. **Document** that other heaps are multi-way, not binary
-3. **Compare performance** of different k values for the generalized Two-Three structure
-4. **Consider SmallVec** for fixed-arity heaps to avoid allocations for typical nodes
+3. **Compare performance** of different k values for the
+   generalized Two-Three structure
+4. **Consider SmallVec** for fixed-arity heaps to avoid
+   allocations for typical nodes
 
 ## Additional Optimization Consideration
 
 ### SmallVec for Fixed-Arity Heaps
 
 For heaps with fixed arity like TwoThreeHeap:
-- Currently uses `Vec<Option<NonNull<Node>>>` which allocates on heap for every node
+
+- Currently uses `Vec<Option<NonNull<Node>>>` which allocates on
+  heap for every node
 - Typical nodes have 2-3 children (very predictable)
-- `SmallVec<[Option<NonNull<Node>>; 3]>` could eliminate allocations in 99%+ of cases
+- `SmallVec<[Option<NonNull<Node>>; 3]>` could eliminate
+  allocations in 99%+ of cases
 - Trade-offs:
-  - **Pros**: No allocations for typical nodes, better cache locality for small heaps
-  - **Cons**: Larger node size (24 bytes overhead vs ~24 bytes for Vec capacity), dependency on `smallvec` crate
-- **Recommendation**: Only worth pursuing if benchmarks show allocation overhead is significant
+  - **Pros**: No allocations for typical nodes, better cache
+    locality for small heaps
+  - **Cons**: Larger node size (24 bytes overhead vs ~24 bytes for
+    Vec capacity), dependency on `smallvec` crate
+- **Recommendation**: Only worth pursuing if benchmarks show
+  allocation overhead is significant
 
 ## Next Steps
 
@@ -558,30 +585,37 @@ For heaps with fixed arity like TwoThreeHeap:
 6. ⏳ Consider renaming TwoThreeHeap to KAryHeap or similar
 7. ⏳ Benchmark SmallVec vs Vec for TwoThreeHeap children storage
 
-**Revised Recommendation**: Start with **TwoThreeHeap generalization** using const generics
+**Revised Recommendation**: Start with **TwoThreeHeap
+generalization** using const generics
 
 **UPDATE**: SmallVec has been integrated into multiple heaps:
+
 - **TwoThreeHeap**: `SmallVec<[Option<NonNull<Node>>; 4]>` for children storage
 - **BinomialHeap**: `SmallVec<[Option<NonNull<Node>>; 32]>` for trees array
-- **SkewBinomialHeap**: `SmallVec<[Option<NonNull<Node>>; 32]>` for trees array
+- **SkewBinomialHeap**: `SmallVec<[Option<NonNull<Node>>; 32]>`
+  for trees array
 
-All implementations eliminate heap allocations for typical small heaps while maintaining the same API and functionality. All tests pass.
+All implementations eliminate heap allocations for typical small
+heaps while maintaining the same API and functionality. All tests
+pass.
 
 ### Additional SmallVec Candidates
 
 Beyond TwoThreeHeap, other heaps have small predictable Vec sizes:
 
-1. **BinomialHeap & SkewBinomialHeap**: ✅ **IMPLEMENTED** 
+1. **BinomialHeap & SkewBinomialHeap**: ✅ **IMPLEMENTED**
    - Size: log₂(n) entries typically (0..30 entries for n < 1 billion)
    - Now use `SmallVec<[Option<NonNull<Node>>; 32]>` to cover heaps up to 2³² elements
    - **Benefits**: Eliminates allocations for heaps up to 4 billion elements
    - All tests pass
 
-2. **BrodalHeap**: `violations: Vec<Vec<NonNull<>>>` 
+2. **BrodalHeap**: `violations: Vec<Vec<NonNull<>>>`
    - Outer Vec: log₂(n) entries (one per rank)
    - Inner Vecs: Small violation lists per rank (typically <10)
    - Could use `SmallVec<[SmallVec<[NonNull<Node>; 8]>; 32]>` (nested)
    - **Complexity**: Nested SmallVec might be overkill
    - **Recommendation**: Maybe just outer Vec, or skip entirely given complexity
 
-3. **General Recommendation**: ✅ All promising candidates now implemented. Skip Brodal unless benchmarks show significant impact. The smallvec dependency is already added for all heaps.
+3. **General Recommendation**: ✅ All promising candidates now
+   implemented. Skip Brodal unless benchmarks show significant
+   impact. The smallvec dependency is already added for all heaps.


### PR DESCRIPTION
This PR fixes all markdown linting issues found by CI:

- Fixed blank lines around headings
- Fixed line length issues (wrapped long lines to 80 characters)
- Fixed blank lines around lists
- Fixed trailing spaces

All markdown files now pass markdownlint validation. The CI markdownlint job should now pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated K-ary investigation documentation with improved readability and clarity through reformatted text, refined wording, and enhanced explanations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->