### PR TITLE
Fix remaining clippy warnings

### DIFF
--- a/src/rank_pairing.rs
+++ b/src/rank_pairing.rs
@@ -626,6 +626,7 @@ impl<T, P: Ord> RankPairingHeap<T, P> {
     }
 
     /// Links two trees of the same rank
+    #[allow(dead_code)]
     unsafe fn link_same_rank(
         &mut self,
         a: NonNull<Node<T, P>>,

--- a/src/skew_binomial.rs
+++ b/src/skew_binomial.rs
@@ -54,11 +54,9 @@ pub struct SkewBinomialHeap<T, P: Ord> {
 
 impl<T, P: Ord> Drop for SkewBinomialHeap<T, P> {
     fn drop(&mut self) {
-        for tree_opt in self.trees.iter() {
-            if let Some(root) = tree_opt {
-                unsafe {
-                    Self::free_tree(*root);
-                }
+        for root in self.trees.iter().flatten() {
+            unsafe {
+                Self::free_tree(*root);
             }
         }
     }
@@ -148,7 +146,7 @@ impl<T, P: Ord> Heap<T, P> for SkewBinomialHeap<T, P> {
             // Insert as rank-0 tree (O(1) in common case)
             // Skew binomial allows O(1) insert via special handling
             // This is the key difference from standard binomial heaps
-            while self.trees.len() <= 0 {
+            if self.trees.is_empty() {
                 self.trees.push(None);
             }
 
@@ -156,7 +154,7 @@ impl<T, P: Ord> Heap<T, P> for SkewBinomialHeap<T, P> {
                 // Rank-0 slot is full: link two rank-0 trees (binary addition carry)
                 // This produces a rank-1 tree
                 let existing = self.trees[0].unwrap();
-                let merged = unsafe { self.link_trees(existing, node_ptr) };
+                let merged = self.link_trees(existing, node_ptr);
                 self.trees[0] = None; // Clear rank-0 slot
 
                 // Try to insert merged tree at rank 1
@@ -168,7 +166,7 @@ impl<T, P: Ord> Heap<T, P> for SkewBinomialHeap<T, P> {
                 if self.trees[1].is_some() {
                     // Rank-1 slot is full: link two rank-1 trees → rank-2 tree
                     let existing_rank1 = self.trees[1].unwrap();
-                    let merged_rank1 = unsafe { self.link_trees(existing_rank1, merged) };
+                    let merged_rank1 = self.link_trees(existing_rank1, merged);
                     self.trees[1] = None; // Clear rank-1 slot
 
                     // Continue cascade to rank 2
@@ -524,6 +522,7 @@ impl<T, P: Ord> SkewBinomialHeap<T, P> {
     /// - Just pointer updates and comparisons
     /// - No traversal needed: linking is a constant-time operation
     /// - This enables efficient merging and insertion
+    #[allow(clippy::only_used_in_recursion)]
     unsafe fn link_trees(
         &mut self,
         a: NonNull<Node<T, P>>,
@@ -613,14 +612,12 @@ impl<T, P: Ord> SkewBinomialHeap<T, P> {
     /// Finds and updates the minimum pointer
     fn find_and_update_min(&mut self) {
         self.min = None;
-        for tree_opt in self.trees.iter() {
-            if let Some(root) = tree_opt {
-                unsafe {
-                    if self.min.is_none()
-                        || (*root.as_ptr()).priority < (*self.min.unwrap().as_ptr()).priority
-                    {
-                        self.min = Some(*root);
-                    }
+        for root in self.trees.iter().flatten() {
+            unsafe {
+                if self.min.is_none()
+                    || (*root.as_ptr()).priority < (*self.min.unwrap().as_ptr()).priority
+                {
+                    self.min = Some(*root);
                 }
             }
         }

--- a/src/strict_fibonacci.rs
+++ b/src/strict_fibonacci.rs
@@ -462,19 +462,15 @@ impl<T, P: Ord> StrictFibonacciHeap<T, P> {
             let mut current = Some(first_child);
             let stop = first_child;
 
-            loop {
-                if let Some(curr) = current {
-                    let next = (*curr.as_ptr()).right;
-                    (*curr.as_ptr()).parent = None;
-                    children.push(curr);
+            while let Some(curr) = current {
+                let next = (*curr.as_ptr()).right;
+                (*curr.as_ptr()).parent = None;
+                children.push(curr);
 
-                    if next == stop {
-                        break;
-                    }
-                    current = Some(next);
-                } else {
+                if next == stop {
                     break;
                 }
+                current = Some(next);
             }
         }
 
@@ -489,22 +485,18 @@ impl<T, P: Ord> StrictFibonacciHeap<T, P> {
             let mut current = Some(root);
             let stop = root;
 
-            loop {
-                if let Some(curr) = current {
-                    if self.min.is_none()
-                        || (*curr.as_ptr()).priority < (*self.min.unwrap().as_ptr()).priority
-                    {
-                        self.min = Some(curr);
-                    }
+            while let Some(curr) = current {
+                if self.min.is_none()
+                    || (*curr.as_ptr()).priority < (*self.min.unwrap().as_ptr()).priority
+                {
+                    self.min = Some(curr);
+                }
 
-                    let next = (*curr.as_ptr()).right;
-                    if next == stop {
-                        break;
-                    }
-                    current = Some(next);
-                } else {
+                let next = (*curr.as_ptr()).right;
+                if next == stop {
                     break;
                 }
+                current = Some(next);
             }
         }
     }
@@ -553,17 +545,13 @@ impl<T, P: Ord> StrictFibonacciHeap<T, P> {
             let mut current = Some(root);
             let stop = root;
 
-            loop {
-                if let Some(curr) = current {
-                    roots.push(curr);
-                    let next = (*curr.as_ptr()).right;
-                    if next == stop {
-                        break;
-                    }
-                    current = Some(next);
-                } else {
+            while let Some(curr) = current {
+                roots.push(curr);
+                let next = (*curr.as_ptr()).right;
+                if next == stop {
                     break;
                 }
+                current = Some(next);
             }
         }
 


### PR DESCRIPTION
This PR fixes all remaining clippy warnings in the source code:

- Remove unnecessary unsafe blocks nested under outer unsafe blocks
- Fix comparison operator (<= 0 -> is_empty())
- Replace if let patterns with .flatten() where appropriate
- Convert loop { if let ... } to while let loops
- Add allow attributes for dead_code and only_used_in_recursion where appropriate

All clippy warnings are now resolved in the source files.