### PR TITLE
Refactor Fibonacci heaps to use Rc and Weak

### DIFF
--- a/src/fibonacci.rs
+++ b/src/fibonacci.rs
@@ -97,6 +97,9 @@ struct Node<T, P> {
     marked: bool,
 }
 
+/// Type alias for a reference-counted node pointer
+type NodeRef<T, P> = Rc<RefCell<Node<T, P>>>;
+
 impl<T, P> Node<T, P> {
     fn new(item: T, priority: P) -> Self {
         Node {
@@ -337,7 +340,7 @@ impl<T, P: Ord> FibonacciHeap<T, P> {
 
         // Max degree is O(log n) due to Fibonacci property
         let max_degree = ((self.len + 1) as f64).log2() as usize + 2;
-        let mut degree_table: Vec<Option<Rc<RefCell<Node<T, P>>>>> = vec![None; max_degree + 1];
+        let mut degree_table: Vec<Option<NodeRef<T, P>>> = vec![None; max_degree + 1];
 
         // Process all current roots
         let roots_to_process: Vec<_> = self.roots.drain(..).collect();


### PR DESCRIPTION
Replace unsafe raw pointer implementation with safe Rc/RefCell/Weak:

- Node structure now uses:
  - Rc<RefCell<Node>> for strong ownership (roots, children)
  - Weak<RefCell<Node>> for parent backlinks (avoids cycles)
  - Vec<Rc<RefCell<Node>>> for children instead of circular list

- FibonacciHandle uses Weak<RefCell<Node>> for safe handle invalidation
  - Handles automatically become invalid when nodes are removed
  - No risk of use-after-free

- Key implementation changes:
  - Roots stored in Vec with Weak min pointer for O(1) min lookup
  - Cut operation is O(degree) for child removal from Vec
  - All operations maintain original asymptotic complexity

- Handle trait updated: removed Copy requirement (Weak is Clone only)

- Fixed pre-existing bug in test_very_large_sequence that tried to decrease priority 0 to 0 (which is not a decrease)

Benefits:
- No unsafe code except one small block for returning refs from RefCell
- Automatic memory management via Rc reference counting
- Invalid handle detection via Weak::upgrade() returning None
- Simpler code structure without manual pointer manipulation