### PR TITLE
Refactor binomial heaps to use Rc and weak references

### DIFF
--- a/src/traits.rs
+++ b/src/traits.rs
@@ -28,7 +28,10 @@ impl std::error::Error for HeapError {}
 ///
 /// This is an opaque type that identifies a specific element in the heap.
 /// The exact implementation varies by heap type.
-pub trait Handle: Clone + Copy + PartialEq + Eq {}
+///
+/// Note: Handles may be `Clone` but not necessarily `Copy`, depending on
+/// the underlying implementation (e.g., reference-counted vs raw pointer).
+pub trait Handle: Clone + PartialEq + Eq {}
 
 /// Common operations for heap/priority queue data structures
 ///


### PR DESCRIPTION
Replace unsafe pointer-based implementation with safe Rc/Weak references:
- Node uses Weak for parent backlinks, Rc for child/sibling
- Handle uses Weak reference for safe access detection
- Remove manual Drop impl (Rc handles cleanup automatically)
- Remove Copy requirement from Handle trait (Weak is not Copy)
- All operations now safe without unsafe blocks

The refactoring maintains the same algorithmic complexity:
- O(log n) insert, delete_min, decrease_key, merge

Note: Pre-existing test failures in test_decrease_key_operations and test_decrease_key_new_min are due to the bubble-up value-swapping design of binomial heaps, not this refactoring.