### PR TITLE
Run markdown linting and fix issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ science literature that provide better amortized bounds:
 ### Implemented Heaps
 
 | Heap Type | Insert | Delete-min | Decrease-key | Merge | Notes |
-|-----------|--------|------------|--------------|-------|-------|
+| --------- | ------ | ---------- | ------------ | ----- | ----- |
 | **Fibonacci** | O(1) am. | O(log n) am. | **O(1) am.** | O(1) | Complex but optimal |
 | **Pairing** | O(1) am. | O(log n) am. | **o(log n) am.** | O(1) | Simpler than Fibonacci |
 | **Rank-Pairing** | O(1) am. | O(log n) am. | **O(1) am.** | O(1) | Simpler than Fibonacci, optimal bounds |

--- a/docs/binomial_heap.md
+++ b/docs/binomial_heap.md
@@ -32,7 +32,7 @@ choice when decrease_key operations are infrequent.
 ## Asymptotic Complexity
 
 | Operation | Time Complexity | Notes |
-|-----------|----------------|-------|
+| --------- | -------------- | ----- |
 | `insert` | **O(log n)** worst-case | Single-element merge |
 | `find_min` | **O(log n)** worst-case | Must scan all roots |
 | `delete_min` | **O(log n)** worst-case | Root removal + merge |
@@ -139,7 +139,7 @@ This is the key difference from Fibonacci heaps: no cutting, just bubble up.
 ## Comparison to Fibonacci Heaps
 
 | Feature | Binomial Heap | Fibonacci Heap |
-|---------|--------------|----------------|
+| ------- | ------------ | -------------- |
 | Insert | O(log n) worst | O(1) amortized |
 | Delete-min | O(log n) worst | O(log n) amortized |
 | Decrease-key | **O(log n) worst** | **O(1) amortized** |

--- a/docs/brodal_heap.md
+++ b/docs/brodal_heap.md
@@ -38,7 +38,7 @@ n) worst-case delete_min.
 ## Asymptotic Complexity
 
 | Operation | Time Complexity | Notes |
-|-----------|----------------|-------|
+| --------- | -------------- | ----- |
 | `insert` | **O(1)** worst-case | Constant time guaranteed |
 | `find_min` | **O(1)** worst-case | Direct pointer to minimum |
 | `delete_min` | **O(log n)** worst-case | Worst-case logarithmic |
@@ -166,7 +166,7 @@ The repair is **local** - only affects the violating node and its children.
 ## Comparison to Fibonacci Heaps
 
 | Feature | Brodal Heap | Fibonacci Heap |
-|---------|------------|----------------|
+| ------- | ---------- | -------------- |
 | Insert | O(1) **worst** | O(1) **amortized** |
 | Delete-min | O(log n) **worst** | O(log n) **amortized** |
 | Decrease-key | O(1) **worst** | O(1) **amortized** |

--- a/docs/fibonacci_heap.md
+++ b/docs/fibonacci_heap.md
@@ -38,7 +38,7 @@ analysis and is often used as a building block for advanced algorithms.
 ## Asymptotic Complexity
 
 | Operation | Time Complexity | Notes |
-|-----------|----------------|-------|
+| --------- | -------------- | ----- |
 | `insert` | **O(1)** amortized | Constant time insertion |
 | `find_min` | **O(1)** | Direct pointer to minimum |
 | `delete_min` | **O(log n)** amortized | Consolidation step |

--- a/docs/pairing_heap.md
+++ b/docs/pairing_heap.md
@@ -38,7 +38,7 @@ while still achieving sub-logarithmic amortized bounds for `decrease_key`.
 ## Asymptotic Complexity
 
 | Operation | Time Complexity | Notes |
-|-----------|----------------|-------|
+| --------- | -------------- | ----- |
 | `insert` | **O(1)** amortized | Constant time amortized insertion |
 | `find_min` | **O(1)** | Direct access to minimum element |
 | `delete_min` | **O(log n)** amortized | Two-pass pairing operation |
@@ -142,7 +142,7 @@ The potential function typically charges:
 ## Comparison to Other Heaps
 
 | Feature | Pairing Heap | Fibonacci Heap | Binary Heap |
-|---------|-------------|----------------|-------------|
+| ------- | ----------- | -------------- | ----------- |
 | Insert | O(1) am. | O(1) am. | O(log n) worst |
 | Delete-min | O(log n) am. | O(log n) am. | O(log n) worst |
 | Decrease-key | **o(log n) am.** | **O(1) am.** | O(log n) worst |

--- a/docs/rank_pairing_heap.md
+++ b/docs/rank_pairing_heap.md
@@ -31,7 +31,7 @@ heaps.
 ## Asymptotic Complexity
 
 | Operation | Time Complexity | Notes |
-|-----------|----------------|-------|
+| --------- | -------------- | ----- |
 | `insert` | **O(1)** amortized | Constant time insertion |
 | `find_min` | **O(1)** | Direct access to minimum |
 | `delete_min` | **O(log n)** amortized | Rank-based merging |

--- a/docs/skew_binomial_heap.md
+++ b/docs/skew_binomial_heap.md
@@ -32,7 +32,7 @@ delete_min and decrease_key operations.
 ## Asymptotic Complexity
 
 | Operation | Time Complexity | Notes |
-|-----------|----------------|-------|
+| --------- | -------------- | ----- |
 | `insert` | **O(1)** worst-case | Constant time insertion |
 | `find_min` | **O(1)** | Direct access to minimum |
 | `delete_min` | **O(log n)** worst-case | Tree traversal and merging |
@@ -127,7 +127,7 @@ This is the same as binomial heaps - no improvement here.
 ## Comparison to Binomial Heaps
 
 | Feature | Skew Binomial | Standard Binomial |
-|---------|--------------|-------------------|
+| ------- | ------------ | ----------------- |
 | Insert | **O(1)** worst | **O(log n)** worst |
 | Merge | **O(1)** worst | **O(log n)** worst |
 | Delete-min | O(log n) worst | O(log n) worst |

--- a/docs/strict_fibonacci_heap.md
+++ b/docs/strict_fibonacci_heap.md
@@ -29,7 +29,7 @@ worst-case delete_min.
 ## Asymptotic Complexity
 
 | Operation | Time Complexity | Notes |
-|-----------|----------------|-------|
+| --------- | -------------- | ----- |
 | `insert` | **O(1)** worst-case | Constant time guaranteed |
 | `find_min` | **O(1)** worst-case | Direct pointer to minimum |
 | `delete_min` | **O(log n)** worst-case | Worst-case logarithmic |
@@ -141,7 +141,7 @@ This is the key insight: by maintaining stricter structure, we prevent cascades.
 ## Comparison to Standard Fibonacci Heaps
 
 | Feature | Strict Fibonacci | Standard Fibonacci |
-|---------|------------------|-------------------|
+| ------- | ---------------- | ----------------- |
 | Insert | O(1) **worst** | O(1) **amortized** |
 | Delete-min | O(log n) **worst** | O(log n) **amortized** |
 | Decrease-key | O(1) **worst** | O(1) **amortized** |

--- a/docs/twothree_heap.md
+++ b/docs/twothree_heap.md
@@ -32,7 +32,7 @@ operations while maintaining good performance for decrease_key operations.
 ## Asymptotic Complexity
 
 | Operation | Time Complexity | Notes |
-|-----------|----------------|-------|
+| --------- | -------------- | ----- |
 | `insert` | **O(1)** amortized | Constant time amortized insertion |
 | `find_min` | **O(1)** | Direct access to minimum |
 | `delete_min` | **O(log n)** amortized | Tree height is O(log n) |
@@ -152,7 +152,7 @@ These operations maintain the 2-3 invariant.
 ## Comparison to Other Heaps
 
 | Feature | 2-3 Heap | Binary Heap | Fibonacci Heap |
-|---------|----------|-------------|----------------|
+| ------- | -------- | ----------- | -------------- |
 | Insert | O(1) am. | O(log n) | O(1) am. |
 | Delete-min | O(log n) am. | O(log n) | O(log n) am. |
 | Decrease-key | O(1) am. | O(log n) | O(1) am. |


### PR DESCRIPTION
Add spaces around pipes in table separator rows to comply with markdownlint's compact style requirements.