### PR TITLE
Fix property test to correctly track handles with duplicate priorities

### DIFF
--- a/tests/property_tests.rs
+++ b/tests/property_tests.rs
@@ -265,11 +265,13 @@ fn test_complex_operations<H: Heap<i32, i32>>(
 ) -> Result<(), TestCaseError> {
     let mut heap = H::new();
     let mut handles = Vec::new();
+    // Track current priority for each handle index
+    // Use handle index as the item value for unique identification
     let mut priorities: HashMap<usize, i32> = HashMap::new();
 
-    // Insert initial values
+    // Insert initial values with unique item (the index)
     for (i, priority) in initial.iter().enumerate() {
-        let handle = heap.push(*priority, *priority);
+        let handle = heap.push(*priority, i as i32);
         handles.push(handle);
         priorities.insert(i, *priority);
     }
@@ -278,9 +280,9 @@ fn test_complex_operations<H: Heap<i32, i32>>(
     for (op_type, value) in ops {
         match op_type % 4 {
             0 => {
-                // Push
+                // Push with unique item (the index)
                 let idx = handles.len();
-                let handle = heap.push(value, value);
+                let handle = heap.push(value, idx as i32);
                 handles.push(handle);
                 priorities.insert(idx, value);
             }
@@ -288,11 +290,10 @@ fn test_complex_operations<H: Heap<i32, i32>>(
                 // Pop
                 if !heap.is_empty() {
                     let popped = heap.pop();
-                    if let Some((priority, _item)) = popped {
-                        // Find and remove from priorities map
-                        if let Some((&idx, _)) = priorities.iter().find(|(_, &p)| p == priority) {
-                            priorities.remove(&idx);
-                        }
+                    if let Some((_priority, item)) = popped {
+                        // Item is the handle index, so we can directly identify which was popped
+                        let idx = item as usize;
+                        priorities.remove(&idx);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
Fix `test_complex_operations` in property tests to correctly track which handle was popped when multiple elements have the same priority.

## Problem
The test was using priority values as item values (`heap.push(*priority, *priority)`), which made it impossible to correctly identify which handle was popped when duplicates existed.

## Solution
Use the handle index as the item value instead (`heap.push(*priority, i as i32)`), providing a unique identifier for each inserted element.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test logic to use insertion indices as unique identifiers for tracking test items, improving test reliability and accuracy when validating complex operations involving multiple insertions and removals.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->