### PR TITLE
Refactor rank pairing heaps with Rc and weak refs

### DIFF
--- a/src/rank_pairing.rs
+++ b/src/rank_pairing.rs
@@ -633,7 +633,11 @@ impl<T, P: Ord> RankPairingHeap<T, P> {
             let mut current = parent.borrow().child.clone();
             while let Some(curr) = current {
                 let curr_sibling = curr.borrow().sibling.clone();
-                if curr_sibling.as_ref().map(|s| Rc::ptr_eq(s, node)).unwrap_or(false) {
+                if curr_sibling
+                    .as_ref()
+                    .map(|s| Rc::ptr_eq(s, node))
+                    .unwrap_or(false)
+                {
                     // Found node: skip it in sibling chain
                     curr.borrow_mut().sibling = node_sibling.clone();
                     break;


### PR DESCRIPTION
Replace the unsafe raw pointer implementation with safe Rc/Weak references, following the same pattern used in other heap implementations.

Key changes:
- Replace NonNull<Node<T, P>> with Rc<RefCell<Node<T, P>>> for child/sibling
- Replace raw pointer parent with Weak<RefCell<Node<T, P>>>
- Replace type-erased *const () handle with NodeWeak<T, P>
- Remove manual Drop implementation (Rc handles cleanup automatically)
- Remove free_node function (no longer needed)
- Add manual Clone, PartialEq, Eq implementations for handle
- Convert all unsafe pointer dereferences to safe borrow()/borrow_mut()

This improves memory safety while maintaining the same algorithmic properties and performance characteristics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * RankPairingHandle and RankPairingHeap are now publicly accessible for direct use.

* **Refactor**
  * Improved memory management with safer, type-system-based reference handling.
  * Eliminated unsafe code blocks, enhancing reliability and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->