### PR TITLE
Rename methods to Rust conventions: peek, pop, push

### DIFF
--- a/src/binomial.rs
+++ b/src/binomial.rs
@@ -129,9 +129,9 @@ struct Node<T, P> {
 /// use rust_advanced_heaps::Heap;
 ///
 /// let mut heap = BinomialHeap::new();
-/// let handle = heap.insert(5, "item");
+/// let handle = heap.push(5, "item");
 /// heap.decrease_key(&handle, 1);
-/// assert_eq!(heap.find_min(), Some((&1, &"item")));
+/// assert_eq!(heap.peek(), Some((&1, &"item")));
 /// ```
 pub struct BinomialHeap<T, P: Ord> {
     /// Array of binomial trees indexed by degree. Each slot holds at most one tree.
@@ -163,10 +163,6 @@ impl<T, P: Ord> Heap<T, P> for BinomialHeap<T, P> {
         self.len
     }
 
-    fn push(&mut self, priority: P, item: T) -> Self::Handle {
-        self.insert(priority, item)
-    }
-
     /// Inserts a new element into the heap
     ///
     /// **Time Complexity**: O(log n) worst-case
@@ -189,7 +185,7 @@ impl<T, P: Ord> Heap<T, P> for BinomialHeap<T, P> {
     /// **Invariant**: After insert, at most one tree of each degree (maintained by
     /// the carry propagation process, just like binary addition maintains at most
     /// one bit per position).
-    fn insert(&mut self, priority: P, item: T) -> Self::Handle {
+    fn push(&mut self, priority: P, item: T) -> Self::Handle {
         // Create new single-node tree (B₀ tree, degree 0)
         let node = Rc::new(RefCell::new(Node {
             item,
@@ -237,10 +233,6 @@ impl<T, P: Ord> Heap<T, P> for BinomialHeap<T, P> {
     }
 
     fn peek(&self) -> Option<(&P, &T)> {
-        self.find_min()
-    }
-
-    fn find_min(&self) -> Option<(&P, &T)> {
         // We need to return references that live as long as self
         // Since RefCell borrows are temporary, we search the trees array
         // and use pointer magic to get stable references
@@ -255,10 +247,6 @@ impl<T, P: Ord> Heap<T, P> for BinomialHeap<T, P> {
         // 3. RefCell contents won't move while we hold &self
         let node_ptr = min_rc.as_ptr();
         unsafe { Some((&(*node_ptr).priority, &(*node_ptr).item)) }
-    }
-
-    fn pop(&mut self) -> Option<(P, T)> {
-        self.delete_min()
     }
 
     /// Removes and returns the minimum element
@@ -284,7 +272,7 @@ impl<T, P: Ord> Heap<T, P> for BinomialHeap<T, P> {
     /// **Binomial Tree Property**: When the root of a Bₖ tree is removed, its
     /// children are Bₖ₋₁, Bₖ₋₂, ..., B₀ trees. This maintains the binomial
     /// tree structure after deletion.
-    fn delete_min(&mut self) -> Option<(P, T)> {
+    fn pop(&mut self) -> Option<(P, T)> {
         let min_weak = self.min.take()?;
         let min_rc = min_weak.upgrade()?;
 

--- a/src/fibonacci.rs
+++ b/src/fibonacci.rs
@@ -140,9 +140,9 @@ impl<T, P> Node<T, P> {
 /// use rust_advanced_heaps::Heap;
 ///
 /// let mut heap = FibonacciHeap::new();
-/// let handle = heap.insert(5, "item");
+/// let handle = heap.push(5, "item");
 /// heap.decrease_key(&handle, 1);
-/// assert_eq!(heap.find_min(), Some((&1, &"item")));
+/// assert_eq!(heap.peek(), Some((&1, &"item")));
 /// ```
 pub struct FibonacciHeap<T, P: Ord> {
     /// All root trees (strong references)
@@ -179,10 +179,6 @@ impl<T, P: Ord> Heap<T, P> for FibonacciHeap<T, P> {
     }
 
     fn push(&mut self, priority: P, item: T) -> Self::Handle {
-        self.insert(priority, item)
-    }
-
-    fn insert(&mut self, priority: P, item: T) -> Self::Handle {
         let node = Rc::new(RefCell::new(Node::new(item, priority)));
         let handle = FibonacciHandle {
             node: Rc::downgrade(&node),
@@ -205,10 +201,6 @@ impl<T, P: Ord> Heap<T, P> for FibonacciHeap<T, P> {
     }
 
     fn peek(&self) -> Option<(&P, &T)> {
-        self.find_min()
-    }
-
-    fn find_min(&self) -> Option<(&P, &T)> {
         self.min.upgrade().map(|min_rc| {
             // SAFETY: We're returning references to data inside RefCell.
             // This is safe because:
@@ -224,10 +216,6 @@ impl<T, P: Ord> Heap<T, P> for FibonacciHeap<T, P> {
     }
 
     fn pop(&mut self) -> Option<(P, T)> {
-        self.delete_min()
-    }
-
-    fn delete_min(&mut self) -> Option<(P, T)> {
         // Find min in roots using the weak reference
         let min_idx = {
             let min_rc = self.min.upgrade()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,10 +22,10 @@
 //! use rust_advanced_heaps::Heap;
 //!
 //! let mut heap = FibonacciHeap::new();
-//! let handle1 = heap.insert(5, "item1");
-//! let handle2 = heap.insert(3, "item2");
+//! let handle1 = heap.push(5, "item1");
+//! let handle2 = heap.push(3, "item2");
 //! heap.decrease_key(&handle1, 1);
-//! assert_eq!(heap.find_min(), Some((&1, &"item1")));
+//! assert_eq!(heap.peek(), Some((&1, &"item1")));
 //! ```
 
 pub mod binomial;

--- a/src/pairing.rs
+++ b/src/pairing.rs
@@ -128,9 +128,9 @@ struct Node<T, P> {
 /// use rust_advanced_heaps::Heap;
 ///
 /// let mut heap = PairingHeap::new();
-/// let handle = heap.insert(5, "item");
+/// let handle = heap.push(5, "item");
 /// heap.decrease_key(&handle, 1);
-/// assert_eq!(heap.find_min(), Some((&1, &"item")));
+/// assert_eq!(heap.peek(), Some((&1, &"item")));
 /// ```
 pub struct PairingHeap<T, P: Ord> {
     /// Root of the heap tree. Uses strong reference as the heap owns the root.
@@ -157,10 +157,6 @@ impl<T, P: Ord> Heap<T, P> for PairingHeap<T, P> {
         self.len
     }
 
-    fn push(&mut self, priority: P, item: T) -> Self::Handle {
-        self.insert(priority, item)
-    }
-
     /// Inserts a new element into the heap
     ///
     /// **Time Complexity**: O(1) amortized
@@ -178,7 +174,7 @@ impl<T, P: Ord> Heap<T, P> for PairingHeap<T, P> {
     /// - Heap property maintained: smaller priority becomes parent
     /// - Tree structure preserved: parent-child relationships correctly linked
     /// - Root always points to minimum: updated if new element is smaller
-    fn insert(&mut self, priority: P, item: T) -> Self::Handle {
+    fn push(&mut self, priority: P, item: T) -> Self::Handle {
         // Create new node with no children or siblings yet
         let node = Rc::new(RefCell::new(Node {
             item,
@@ -221,10 +217,6 @@ impl<T, P: Ord> Heap<T, P> for PairingHeap<T, P> {
     }
 
     fn peek(&self) -> Option<(&P, &T)> {
-        self.find_min()
-    }
-
-    fn find_min(&self) -> Option<(&P, &T)> {
         // Safety: The references we return point to data inside an Rc that the heap owns.
         // As long as the caller has a borrow of &self, the Rc stays alive and the data is valid.
         // This is effectively a lifetime extension that is safe because:
@@ -235,10 +227,6 @@ impl<T, P: Ord> Heap<T, P> for PairingHeap<T, P> {
             let node = root.as_ptr();
             unsafe { (&(*node).priority, &(*node).item) }
         })
-    }
-
-    fn pop(&mut self) -> Option<(P, T)> {
-        self.delete_min()
     }
 
     /// Removes and returns the minimum element
@@ -265,7 +253,7 @@ impl<T, P: Ord> Heap<T, P> for PairingHeap<T, P> {
     /// - Single pass (left-to-right) would create an unbalanced structure
     /// - Two passes ensure logarithmic height in the amortized sense
     /// - Right-to-left merge in second pass balances the tree better
-    fn delete_min(&mut self) -> Option<(P, T)> {
+    fn pop(&mut self) -> Option<(P, T)> {
         let root = self.root.take()?;
 
         // Get the first child before we consume the root

--- a/src/rank_pairing.rs
+++ b/src/rank_pairing.rs
@@ -139,9 +139,9 @@ struct Node<T, P> {
 /// use rust_advanced_heaps::Heap;
 ///
 /// let mut heap = RankPairingHeap::new();
-/// let handle = heap.insert(5, "item");
+/// let handle = heap.push(5, "item");
 /// heap.decrease_key(&handle, 1);
-/// assert_eq!(heap.find_min(), Some((&1, &"item")));
+/// assert_eq!(heap.peek(), Some((&1, &"item")));
 /// ```
 pub struct RankPairingHeap<T, P: Ord> {
     /// Root of the heap tree. Uses strong reference as the heap owns the root.
@@ -168,10 +168,6 @@ impl<T, P: Ord> Heap<T, P> for RankPairingHeap<T, P> {
         self.len
     }
 
-    fn push(&mut self, priority: P, item: T) -> Self::Handle {
-        self.insert(priority, item)
-    }
-
     /// Inserts a new element into the heap
     ///
     /// **Time Complexity**: O(1) amortized
@@ -190,7 +186,7 @@ impl<T, P: Ord> Heap<T, P> for RankPairingHeap<T, P> {
     /// **Invariant Maintenance**:
     /// - Heap property: smaller priority becomes parent
     /// - Rank constraints: ranks updated to satisfy rank(v) ≤ rank(w₁) + 1 and rank(v) ≤ rank(w₂) + 1
-    fn insert(&mut self, priority: P, item: T) -> Self::Handle {
+    fn push(&mut self, priority: P, item: T) -> Self::Handle {
         // Create new node with rank 0 (leaf node, no children)
         let node = Rc::new(RefCell::new(Node {
             item,
@@ -230,10 +226,6 @@ impl<T, P: Ord> Heap<T, P> for RankPairingHeap<T, P> {
     }
 
     fn peek(&self) -> Option<(&P, &T)> {
-        self.find_min()
-    }
-
-    fn find_min(&self) -> Option<(&P, &T)> {
         // Safety: The references we return point to data inside an Rc that the heap owns.
         // As long as the caller has a borrow of &self, the Rc stays alive and the data is valid.
         // This is effectively a lifetime extension that is safe because:
@@ -244,10 +236,6 @@ impl<T, P: Ord> Heap<T, P> for RankPairingHeap<T, P> {
             let node = root.as_ptr();
             unsafe { (&(*node).priority, &(*node).item) }
         })
-    }
-
-    fn pop(&mut self) -> Option<(P, T)> {
-        self.delete_min()
     }
 
     /// Removes and returns the minimum element
@@ -269,7 +257,7 @@ impl<T, P: Ord> Heap<T, P> for RankPairingHeap<T, P> {
     /// - At most O(log n) children (bounded by rank constraints)
     /// - Merging maintains rank constraints
     /// - Amortized analysis shows the pairing strategy achieves O(log n) total cost
-    fn delete_min(&mut self) -> Option<(P, T)> {
+    fn pop(&mut self) -> Option<(P, T)> {
         let root = self.root.take()?;
 
         // Collect all children of the root (clearing their parent links)

--- a/src/skew_binomial.rs
+++ b/src/skew_binomial.rs
@@ -101,10 +101,6 @@ impl<T, P: Ord> Heap<T, P> for SkewBinomialHeap<T, P> {
     }
 
     fn push(&mut self, priority: P, item: T) -> Self::Handle {
-        self.insert(priority, item)
-    }
-
-    fn insert(&mut self, priority: P, item: T) -> Self::Handle {
         let node = Rc::new(RefCell::new(Node {
             item: Some(item),
             priority: Some(priority),
@@ -131,10 +127,6 @@ impl<T, P: Ord> Heap<T, P> for SkewBinomialHeap<T, P> {
     }
 
     fn peek(&self) -> Option<(&P, &T)> {
-        self.find_min()
-    }
-
-    fn find_min(&self) -> Option<(&P, &T)> {
         self.min.as_ref().map(|min_ref| unsafe {
             let ptr = min_ref.as_ptr();
             (
@@ -145,10 +137,6 @@ impl<T, P: Ord> Heap<T, P> for SkewBinomialHeap<T, P> {
     }
 
     fn pop(&mut self) -> Option<(P, T)> {
-        self.delete_min()
-    }
-
-    fn delete_min(&mut self) -> Option<(P, T)> {
         let min_ref = self.min.take()?;
 
         // Clear from trees

--- a/src/strict_fibonacci.rs
+++ b/src/strict_fibonacci.rs
@@ -148,10 +148,6 @@ impl<T, P: Ord> Heap<T, P> for StrictFibonacciHeap<T, P> {
         self.len
     }
 
-    fn push(&mut self, priority: P, item: T) -> Self::Handle {
-        self.insert(priority, item)
-    }
-
     /// Inserts a new element into the heap
     ///
     /// **Time Complexity**: O(1) worst-case
@@ -161,7 +157,7 @@ impl<T, P: Ord> Heap<T, P> for StrictFibonacciHeap<T, P> {
     /// 2. Add to active root list
     /// 3. Update minimum pointer if necessary
     /// 4. Perform conditional consolidation (worst-case O(1))
-    fn insert(&mut self, priority: P, item: T) -> Self::Handle {
+    fn push(&mut self, priority: P, item: T) -> Self::Handle {
         let node = Node::new(priority, item);
         let handle = StrictFibonacciHandle {
             node: Rc::downgrade(&node),
@@ -195,10 +191,6 @@ impl<T, P: Ord> Heap<T, P> for StrictFibonacciHeap<T, P> {
     }
 
     fn peek(&self) -> Option<(&P, &T)> {
-        self.find_min()
-    }
-
-    fn find_min(&self) -> Option<(&P, &T)> {
         self.min.as_ref().and_then(|min_weak| {
             min_weak.upgrade().map(|min_rc| {
                 let node = min_rc.as_ptr();
@@ -208,10 +200,6 @@ impl<T, P: Ord> Heap<T, P> for StrictFibonacciHeap<T, P> {
                 unsafe { (&(*node).priority, &(*node).item) }
             })
         })
-    }
-
-    fn pop(&mut self) -> Option<(P, T)> {
-        self.delete_min()
     }
 
     /// Removes and returns the minimum element
@@ -224,7 +212,7 @@ impl<T, P: Ord> Heap<T, P> for StrictFibonacciHeap<T, P> {
     /// 3. Add children to active root list
     /// 4. Find new minimum by scanning roots (O(log n))
     /// 5. Consolidate all roots (O(log n))
-    fn delete_min(&mut self) -> Option<(P, T)> {
+    fn pop(&mut self) -> Option<(P, T)> {
         let min_weak = self.min.take()?;
 
         // Find the minimum in roots using the weak reference

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -63,7 +63,6 @@ pub trait Heap<T, P: Ord> {
 
     /// Inserts an element with the given priority, returning a handle
     ///
-    /// Equivalent to `BinaryHeap::push`, but returns a handle for `decrease_key`.
     /// The handle can be used later with `decrease_key` to update the priority.
     ///
     /// # Time Complexity
@@ -71,22 +70,11 @@ pub trait Heap<T, P: Ord> {
     /// - Pairing Heap: O(1) amortized
     /// - Rank-Pairing Heap: O(1) amortized
     /// - Binomial Heap: O(log n)
-    /// - Brodal Heap: O(1) worst-case
     fn push(&mut self, priority: P, item: T) -> Self::Handle;
-
-    /// Inserts an element with the given priority, returning a handle
-    ///
-    /// Alias for `push` for consistency with older API.
-    /// Prefer using `push` for compatibility with standard Rust heaps.
-    #[inline]
-    fn insert(&mut self, priority: P, item: T) -> Self::Handle {
-        self.push(priority, item)
-    }
 
     /// Returns the minimum priority and associated item without removing it
     ///
-    /// Equivalent to `BinaryHeap::peek`. Note that `BinaryHeap` is a max-heap,
-    /// while these heaps are min-heaps.
+    /// Note that `BinaryHeap` is a max-heap, while these heaps are min-heaps.
     ///
     /// # Lifetime Safety
     ///
@@ -104,36 +92,16 @@ pub trait Heap<T, P: Ord> {
     /// All implementations: O(1)
     fn peek(&self) -> Option<(&P, &T)>;
 
-    /// Returns the minimum priority and associated item without removing it
-    ///
-    /// Alias for `peek` for consistency with older API.
-    /// Prefer using `peek` for compatibility with standard Rust heaps.
-    #[inline]
-    fn find_min(&self) -> Option<(&P, &T)> {
-        self.peek()
-    }
-
     /// Removes and returns the minimum priority and associated item
     ///
-    /// Equivalent to `BinaryHeap::pop`. Note that `BinaryHeap` is a max-heap,
-    /// while these heaps are min-heaps.
+    /// Note that `BinaryHeap` is a max-heap, while these heaps are min-heaps.
     ///
     /// # Time Complexity
     /// - Fibonacci Heap: O(log n) amortized
     /// - Pairing Heap: O(log n) amortized
     /// - Rank-Pairing Heap: O(log n) amortized
     /// - Binomial Heap: O(log n)
-    /// - Brodal Heap: O(log n) worst-case
     fn pop(&mut self) -> Option<(P, T)>;
-
-    /// Removes and returns the minimum priority and associated item
-    ///
-    /// Alias for `pop` for consistency with older API.
-    /// Prefer using `pop` for compatibility with standard Rust heaps.
-    #[inline]
-    fn delete_min(&mut self) -> Option<(P, T)> {
-        self.pop()
-    }
 
     /// Decreases the priority of an element identified by the handle
     ///
@@ -154,18 +122,14 @@ pub trait Heap<T, P: Ord> {
     /// - Pairing Heap: o(log n) amortized
     /// - Rank-Pairing Heap: O(1) amortized
     /// - Binomial Heap: O(log n)
-    /// - Brodal Heap: O(1) worst-case
     fn decrease_key(&mut self, handle: &Self::Handle, new_priority: P) -> Result<(), HeapError>;
 
     /// Merges another heap into this one, consuming the other heap
-    ///
-    /// Similar to `BinaryHeap::append`, but consumes the other heap.
     ///
     /// # Time Complexity
     /// - Fibonacci Heap: O(1)
     /// - Pairing Heap: O(1)
     /// - Rank-Pairing Heap: O(1)
     /// - Binomial Heap: O(log n)
-    /// - Brodal Heap: O(1) worst-case
     fn merge(&mut self, other: Self);
 }

--- a/src/twothree.rs
+++ b/src/twothree.rs
@@ -146,10 +146,6 @@ impl<T, P: Ord + Clone> Heap<T, P> for TwoThreeHeap<T, P> {
     }
 
     fn push(&mut self, priority: P, item: T) -> Self::Handle {
-        self.insert(priority, item)
-    }
-
-    fn insert(&mut self, priority: P, item: T) -> Self::Handle {
         let node = Rc::new(RefCell::new(Node::new(item, priority)));
         let handle = TwoThreeHandle {
             node: Rc::downgrade(&node),
@@ -160,10 +156,6 @@ impl<T, P: Ord + Clone> Heap<T, P> for TwoThreeHeap<T, P> {
     }
 
     fn peek(&self) -> Option<(&P, &T)> {
-        self.find_min()
-    }
-
-    fn find_min(&self) -> Option<(&P, &T)> {
         let min_node = self.find_min_node()?;
         let node = min_node.borrow();
         // SAFETY: The returned references are valid for the lifetime of `&self`:
@@ -181,10 +173,6 @@ impl<T, P: Ord + Clone> Heap<T, P> for TwoThreeHeap<T, P> {
     }
 
     fn pop(&mut self) -> Option<(P, T)> {
-        self.delete_min()
-    }
-
-    fn delete_min(&mut self) -> Option<(P, T)> {
         if self.is_empty() {
             return None;
         }

--- a/tests/generic_heap_tests.rs
+++ b/tests/generic_heap_tests.rs
@@ -22,7 +22,6 @@ fn test_empty_heap<H: Heap<String, i32>>() {
     assert_eq!(heap.len(), 0);
     assert_eq!(heap.peek(), None);
     assert_eq!(heap.pop(), None);
-    assert_eq!(heap.find_min(), None);
 }
 
 /// Test basic insert and pop operations
@@ -625,20 +624,19 @@ fn test_decrease_to_negative<H: Heap<i32, i32>>() {
     assert_eq!(heap.pop(), Some((-5, 1)));
 }
 
-/// Test insert/alias methods (insert, find_min, delete_min)
+/// Test basic push/peek/pop cycle
 fn test_alias_methods<H: Heap<&'static str, i32>>() {
     let mut heap = H::new();
 
-    // Test insert alias
-    let _h = heap.insert(5, "five");
+    // Test push
+    let _h = heap.push(5, "five");
     assert_eq!(heap.len(), 1);
 
-    // Test find_min alias
-    assert_eq!(heap.find_min(), Some((&5, &"five")));
-    assert_eq!(heap.peek(), Some((&5, &"five"))); // Same as find_min
+    // Test peek
+    assert_eq!(heap.peek(), Some((&5, &"five")));
 
-    // Test delete_min alias
-    assert_eq!(heap.delete_min(), Some((5, "five")));
+    // Test pop
+    assert_eq!(heap.pop(), Some((5, "five")));
     assert_eq!(heap.pop(), None); // Should be empty now
 }
 


### PR DESCRIPTION
## Summary

- Renamed `find_min` -> `peek` (standard Rust naming)
- Renamed `delete_min` -> `pop` (standard Rust naming)  
- Renamed `insert` -> `push` (standard Rust naming)
- Removed method aliases (only primary names remain)
- Updated all heap implementations and tests
- Updated docstrings and examples

This aligns our API with Rust's `BinaryHeap` naming conventions.

## Test plan

- [x] All existing tests pass
- [x] Doc tests pass
- [x] Clippy passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor

* **Simplified Heap API**: Removed older method aliases (`insert()`, `find_min()`, `delete_min()`) across all heap implementations. Use the standardized methods instead: `push()` to add elements, `peek()` to view the minimum, and `pop()` to remove and return the minimum element.
* **Updated documentation and tests** to reflect the new standardized method names throughout the codebase.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->