### PR TITLE
feat: add two-tier trait hierarchy with SimpleBinaryHeap

### DIFF
--- a/docs/REFERENCES.md
+++ b/docs/REFERENCES.md
@@ -7,6 +7,7 @@ structures implemented in this crate, ordered by publication date.
 
 | Heap             | Year | decrease-key | Notes                   |
 | ---------------- | ---- | ------------ | ----------------------- |
+| Simple Binary    | 1964 | -            | No decrease_key support |
 | Binomial         | 1978 | O(log n)     | Foundational, simple    |
 | Pairing          | 1986 | o(log n) am. | Simple, fast in practice|
 | Fibonacci        | 1987 | O(1) am.     | Optimal amortized bounds|
@@ -14,6 +15,46 @@ structures implemented in this crate, ordered by publication date.
 | 2-3 Heap         | 1999 | O(1) am.     | Simpler than Fibonacci  |
 | Rank-Pairing     | 2011 | O(1) am.     | Simple + optimal bounds |
 | Strict Fibonacci | 2012 | O(1) worst   | Optimal worst-case      |
+
+---
+
+## Simple Binary Heap (1964)
+
+**Wikipedia:** <https://en.wikipedia.org/wiki/Binary_heap>
+
+**Williams, J. W. J. (1964).** Algorithm 232: Heapsort. *Communications of the
+ACM*, 7(6), 347-348.
+
+**Floyd, R. W. (1964).** Algorithm 245: Treesort 3. *Communications of the ACM*,
+7(12), 701.
+
+The binary heap is one of the most fundamental data structures in computer
+science. Williams introduced it alongside the heapsort algorithm in 1964. Floyd
+published an improvement the same year showing how to build a heap in O(n) time.
+The structure uses a complete binary tree stored implicitly in an array, where
+parent-child relationships are computed from array indices.
+
+- **ACM Digital Library (Williams):** <https://dl.acm.org/doi/10.1145/512274.512284>
+- **ACM Digital Library (Floyd):** <https://dl.acm.org/doi/10.1145/355588.365103>
+
+The original papers are short algorithm descriptions behind the ACM paywall.
+For accessible explanations, see:
+
+- **Wikipedia:** <https://en.wikipedia.org/wiki/Binary_heap>
+- **CLRS textbook:** Cormen et al., *Introduction to Algorithms*, Chapter 6
+
+Note: Rust's standard library already provides `std::collections::BinaryHeap`.
+This crate includes `SimpleBinaryHeap` for completeness and to provide a
+consistent API across all heap types via the `Heap` trait. For algorithms
+requiring priority updates, use one of the advanced heap implementations.
+
+| Operation    | Worst-case Time |
+| ------------ | --------------- |
+| insert       | O(log n)        |
+| find-min     | O(1)            |
+| delete-min   | O(log n)        |
+| decrease-key | -               |
+| merge        | O(n log n)      |
 
 ---
 

--- a/src/fibonacci.rs
+++ b/src/fibonacci.rs
@@ -49,7 +49,7 @@
 //!   [ACM DL](https://dl.acm.org/doi/10.1145/28869.28874)
 //! - [Wikipedia: Fibonacci heap](https://en.wikipedia.org/wiki/Fibonacci_heap)
 
-use crate::traits::{Handle, Heap, HeapError};
+use crate::traits::{DecreaseKeyHeap, Handle, Heap, HeapError};
 use std::cell::RefCell;
 use std::rc::{Rc, Weak};
 
@@ -137,11 +137,11 @@ impl<T, P> Node<T, P> {
 ///
 /// ```rust
 /// use rust_advanced_heaps::fibonacci::FibonacciHeap;
-/// use rust_advanced_heaps::Heap;
+/// use rust_advanced_heaps::{Heap, DecreaseKeyHeap};
 ///
 /// let mut heap = FibonacciHeap::new();
-/// let handle = heap.push(5, "item");
-/// heap.decrease_key(&handle, 1);
+/// let handle = heap.push_with_handle(5, "item");
+/// heap.decrease_key(&handle, 1).unwrap();
 /// assert_eq!(heap.peek(), Some((&1, &"item")));
 /// ```
 pub struct FibonacciHeap<T, P: Ord> {
@@ -160,8 +160,6 @@ impl<T, P: Ord> Default for FibonacciHeap<T, P> {
 }
 
 impl<T, P: Ord> Heap<T, P> for FibonacciHeap<T, P> {
-    type Handle = FibonacciHandle<T, P>;
-
     fn new() -> Self {
         Self {
             roots: Vec::new(),
@@ -178,26 +176,8 @@ impl<T, P: Ord> Heap<T, P> for FibonacciHeap<T, P> {
         self.len
     }
 
-    fn push(&mut self, priority: P, item: T) -> Self::Handle {
-        let node = Rc::new(RefCell::new(Node::new(item, priority)));
-        let handle = FibonacciHandle {
-            node: Rc::downgrade(&node),
-        };
-
-        // Update min if necessary
-        let should_update_min = if let Some(min_rc) = self.min.upgrade() {
-            node.borrow().priority < min_rc.borrow().priority
-        } else {
-            true // No current min, so this becomes min
-        };
-
-        if should_update_min {
-            self.min = Rc::downgrade(&node);
-        }
-
-        self.roots.push(node);
-        self.len += 1;
-        handle
+    fn push(&mut self, priority: P, item: T) {
+        let _ = self.push_with_handle(priority, item);
     }
 
     fn peek(&self) -> Option<(&P, &T)> {
@@ -259,6 +239,63 @@ impl<T, P: Ord> Heap<T, P> for FibonacciHeap<T, P> {
         Some((node.priority, node.item))
     }
 
+    fn merge(&mut self, mut other: Self) {
+        if other.is_empty() {
+            return;
+        }
+
+        if self.is_empty() {
+            *self = other;
+            return;
+        }
+
+        // Compare mins and update
+        let other_is_smaller =
+            if let (Some(self_min), Some(other_min)) = (self.min.upgrade(), other.min.upgrade()) {
+                other_min.borrow().priority < self_min.borrow().priority
+            } else {
+                other.min.upgrade().is_some()
+            };
+
+        if other_is_smaller {
+            self.min = other.min.clone();
+        }
+
+        // Append other's roots to self
+        self.roots.append(&mut other.roots);
+        self.len += other.len;
+
+        // Prevent double-cleanup
+        other.min = Weak::new();
+        other.len = 0;
+    }
+}
+
+impl<T, P: Ord> DecreaseKeyHeap<T, P> for FibonacciHeap<T, P> {
+    type Handle = FibonacciHandle<T, P>;
+
+    fn push_with_handle(&mut self, priority: P, item: T) -> Self::Handle {
+        let node = Rc::new(RefCell::new(Node::new(item, priority)));
+        let handle = FibonacciHandle {
+            node: Rc::downgrade(&node),
+        };
+
+        // Update min if necessary
+        let should_update_min = if let Some(min_rc) = self.min.upgrade() {
+            node.borrow().priority < min_rc.borrow().priority
+        } else {
+            true // No current min, so this becomes min
+        };
+
+        if should_update_min {
+            self.min = Rc::downgrade(&node);
+        }
+
+        self.roots.push(node);
+        self.len += 1;
+        handle
+    }
+
     fn decrease_key(&mut self, handle: &Self::Handle, new_priority: P) -> Result<(), HeapError> {
         // Upgrade weak reference to get the node
         let node_rc = match handle.node.upgrade() {
@@ -299,37 +336,6 @@ impl<T, P: Ord> Heap<T, P> for FibonacciHeap<T, P> {
         self.maybe_update_min(&node_rc);
 
         Ok(())
-    }
-
-    fn merge(&mut self, mut other: Self) {
-        if other.is_empty() {
-            return;
-        }
-
-        if self.is_empty() {
-            *self = other;
-            return;
-        }
-
-        // Compare mins and update
-        let other_is_smaller =
-            if let (Some(self_min), Some(other_min)) = (self.min.upgrade(), other.min.upgrade()) {
-                other_min.borrow().priority < self_min.borrow().priority
-            } else {
-                other.min.upgrade().is_some()
-            };
-
-        if other_is_smaller {
-            self.min = other.min.clone();
-        }
-
-        // Append other's roots to self
-        self.roots.append(&mut other.roots);
-        self.len += other.len;
-
-        // Prevent double-cleanup
-        other.min = Weak::new();
-        other.len = 0;
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,26 +5,51 @@
 //! This crate provides implementations of various advanced heap/priority queue data structures
 //! with efficient `decrease_key` support, as described in computer science literature.
 //!
-//! # Features
+//! # Trait Hierarchy
 //!
-//! - **Fibonacci Heap**: O(1) amortized insert, decrease_key, and merge; O(log n) amortized delete-min
-//! - **Pairing Heap**: O(1) amortized insert and merge; O(log n) amortized delete-min; o(log n) amortized decrease_key
-//! - **Rank-Pairing Heap**: O(1) amortized insert, decrease_key, and merge; O(log n) amortized delete-min
-//! - **Binomial Heap**: O(log n) insert and delete-min; O(log n) decrease_key; O(1) amortized merge
-//! - **Strict Fibonacci Heap**: O(1) worst-case insert, decrease_key, and merge; O(log n) worst-case delete-min
-//! - **2-3 Heap**: O(1) amortized insert and decrease_key; O(log n) amortized delete-min
-//! - **Skew Binomial Heap**: O(1) insert and merge; O(log n) delete-min and decrease_key
+//! This crate provides a two-tier trait design:
 //!
-//! # Example
+//! - [`Heap`]: Base trait for simple heaps (push, pop, peek, merge)
+//! - [`DecreaseKeyHeap`]: Extended trait adding `decrease_key` and handle-based operations
+//!
+//! This allows algorithms to be generic over heaps at the appropriate level.
+//!
+//! # Implementations
+//!
+//! | Heap | push | pop | decrease_key | Trait |
+//! |------|------|-----|--------------|-------|
+//! | [`simple_binary::SimpleBinaryHeap`] | O(log n) | O(log n) | - | `Heap` only |
+//! | [`fibonacci::FibonacciHeap`] | O(1) am. | O(log n) am. | O(1) am. | `DecreaseKeyHeap` |
+//! | [`pairing::PairingHeap`] | O(1) am. | O(log n) am. | o(log n) am. | `DecreaseKeyHeap` |
+//! | [`rank_pairing::RankPairingHeap`] | O(1) am. | O(log n) am. | O(1) am. | `DecreaseKeyHeap` |
+//! | [`binomial::BinomialHeap`] | O(log n) | O(log n) | O(log n) | `DecreaseKeyHeap` |
+//! | [`strict_fibonacci::StrictFibonacciHeap`] | O(1) worst | O(log n) worst | O(1) worst | `DecreaseKeyHeap` |
+//! | [`twothree::TwoThreeHeap`] | O(1) am. | O(log n) am. | O(1) am. | `DecreaseKeyHeap` |
+//! | [`skew_binomial::SkewBinomialHeap`] | O(1) | O(log n) | O(log n) | `DecreaseKeyHeap` |
+//!
+//! # Basic Example
 //!
 //! ```rust
-//! use rust_advanced_heaps::fibonacci::FibonacciHeap;
 //! use rust_advanced_heaps::Heap;
+//! use rust_advanced_heaps::simple_binary::SimpleBinaryHeap;
+//!
+//! let mut heap = SimpleBinaryHeap::new();
+//! heap.push(3, "three");
+//! heap.push(1, "one");
+//! assert_eq!(heap.peek(), Some((&1, &"one")));
+//! assert_eq!(heap.pop(), Some((1, "one")));
+//! ```
+//!
+//! # Example with decrease_key
+//!
+//! ```rust
+//! use rust_advanced_heaps::{Heap, DecreaseKeyHeap};
+//! use rust_advanced_heaps::fibonacci::FibonacciHeap;
 //!
 //! let mut heap = FibonacciHeap::new();
-//! let handle1 = heap.push(5, "item1");
-//! let handle2 = heap.push(3, "item2");
-//! heap.decrease_key(&handle1, 1);
+//! let handle1 = heap.push_with_handle(5, "item1");
+//! let _handle2 = heap.push_with_handle(3, "item2");
+//! heap.decrease_key(&handle1, 1).unwrap();
 //! assert_eq!(heap.peek(), Some((&1, &"item1")));
 //! ```
 
@@ -32,11 +57,12 @@ pub mod binomial;
 pub mod fibonacci;
 pub mod pairing;
 pub mod rank_pairing;
+pub mod simple_binary;
 pub mod skew_binomial;
 pub mod stdlib_compat;
 pub mod strict_fibonacci;
 pub mod traits;
 pub mod twothree;
 
-// Re-export the main trait for convenience
-pub use traits::Heap;
+// Re-export the main traits for convenience
+pub use traits::{DecreaseKeyHeap, Heap};

--- a/src/rank_pairing.rs
+++ b/src/rank_pairing.rs
@@ -51,7 +51,7 @@
 //!   [SIAM](https://epubs.siam.org/doi/10.1137/100785351)
 //! - [Wikipedia: Rank-pairing heap](https://en.wikipedia.org/wiki/Rank-pairing_heap)
 
-use crate::traits::{Handle, Heap, HeapError};
+use crate::traits::{DecreaseKeyHeap, Handle, Heap, HeapError};
 use std::cell::RefCell;
 use std::rc::{Rc, Weak};
 
@@ -136,11 +136,11 @@ struct Node<T, P> {
 ///
 /// ```rust
 /// use rust_advanced_heaps::rank_pairing::RankPairingHeap;
-/// use rust_advanced_heaps::Heap;
+/// use rust_advanced_heaps::{Heap, DecreaseKeyHeap};
 ///
 /// let mut heap = RankPairingHeap::new();
-/// let handle = heap.push(5, "item");
-/// heap.decrease_key(&handle, 1);
+/// let handle = heap.push_with_handle(5, "item");
+/// heap.decrease_key(&handle, 1).unwrap();
 /// assert_eq!(heap.peek(), Some((&1, &"item")));
 /// ```
 pub struct RankPairingHeap<T, P: Ord> {
@@ -154,8 +154,6 @@ pub struct RankPairingHeap<T, P: Ord> {
 // which recursively drops all children (via their strong references).
 
 impl<T, P: Ord> Heap<T, P> for RankPairingHeap<T, P> {
-    type Handle = RankPairingHandle<T, P>;
-
     fn new() -> Self {
         Self { root: None, len: 0 }
     }
@@ -168,61 +166,8 @@ impl<T, P: Ord> Heap<T, P> for RankPairingHeap<T, P> {
         self.len
     }
 
-    /// Inserts a new element into the heap
-    ///
-    /// **Time Complexity**: O(1) amortized
-    ///
-    /// **Algorithm**:
-    /// 1. Create a new node with rank 0 (leaf node)
-    /// 2. Compare priority with current root
-    /// 3. If new priority is smaller, make new node the root (old root becomes child)
-    /// 4. Otherwise, add new node as a child of the root
-    /// 5. Update ranks to maintain rank constraints
-    ///
-    /// **Rank Update**: When a node becomes a parent, its rank is updated based on
-    /// its children's ranks. Rank = min(rank(w₁), rank(w₂)) + 1 where w₁, w₂ are
-    /// children with smallest ranks. This maintains the rank constraint invariant.
-    ///
-    /// **Invariant Maintenance**:
-    /// - Heap property: smaller priority becomes parent
-    /// - Rank constraints: ranks updated to satisfy rank(v) ≤ rank(w₁) + 1 and rank(v) ≤ rank(w₂) + 1
-    fn push(&mut self, priority: P, item: T) -> Self::Handle {
-        // Create new node with rank 0 (leaf node, no children)
-        let node = Rc::new(RefCell::new(Node {
-            item,
-            priority,
-            parent: None,
-            child: None,
-            sibling: None,
-            rank: 0,       // Leaf nodes have rank 0
-            marked: false, // New nodes are unmarked
-        }));
-
-        // Link new node into the tree structure
-        if let Some(ref root) = self.root {
-            if node.borrow().priority < root.borrow().priority {
-                // Case 1: New node has smaller priority
-                // Make new node the root, old root becomes its child
-                // This maintains heap property: parent <= child
-                Self::make_child(&node, root);
-                // Update root pointer to new minimum
-                self.root = Some(Rc::clone(&node));
-            } else {
-                // Case 2: Current root has smaller or equal priority
-                // Add new node as a child of the root
-                // Heap property maintained: new node >= root
-                Self::make_child(root, &node);
-                // Root stays the same
-            }
-        } else {
-            // Empty heap: new node becomes root
-            self.root = Some(Rc::clone(&node));
-        }
-
-        self.len += 1;
-        RankPairingHandle {
-            node: Rc::downgrade(&node),
-        }
+    fn push(&mut self, priority: P, item: T) {
+        let _ = self.push_with_handle(priority, item);
     }
 
     fn peek(&self) -> Option<(&P, &T)> {
@@ -296,6 +241,115 @@ impl<T, P: Ord> Heap<T, P> for RankPairingHeap<T, P> {
         });
         let node = cell.into_inner();
         Some((node.priority, node.item))
+    }
+
+    /// Merges another heap into this heap
+    ///
+    /// **Time Complexity**: O(1) amortized
+    ///
+    /// **Algorithm**:
+    /// 1. Compare roots of both heaps
+    /// 2. Make the larger-priority root a child of the smaller-priority root
+    /// 3. Update ranks to maintain rank constraints
+    /// 4. The smaller root becomes the new root
+    ///
+    /// This is trivially O(1): we only need one comparison and a few pointer updates.
+    /// The rank update is O(1) because we're just adding one child.
+    ///
+    /// **Post-condition**: After merge, `other` is empty (consumed by this heap)
+    fn merge(&mut self, mut other: Self) {
+        // Empty heaps are easy cases
+        if other.is_empty() {
+            return; // Nothing to merge
+        }
+
+        if self.is_empty() {
+            // This heap is empty: just take the other heap
+            *self = other;
+            return;
+        }
+
+        // Both heaps are non-empty: need to link them
+        let self_root = self.root.take().unwrap();
+        let other_root = other.root.take().unwrap();
+
+        // Compare roots: smaller priority becomes parent (heap property)
+        if other_root.borrow().priority < self_root.borrow().priority {
+            // Other root has smaller priority: it becomes the new root
+            // Self root becomes a child of other root
+            Self::make_child(&other_root, &self_root);
+            self.root = Some(other_root);
+        } else {
+            // Self root has smaller or equal priority: it stays root
+            // Other root becomes a child of self root
+            Self::make_child(&self_root, &other_root);
+            self.root = Some(self_root);
+        }
+
+        // Update length and mark other as empty (prevent double-free)
+        self.len += other.len;
+        other.len = 0;
+    }
+}
+
+impl<T, P: Ord> DecreaseKeyHeap<T, P> for RankPairingHeap<T, P> {
+    type Handle = RankPairingHandle<T, P>;
+
+    /// Inserts a new element into the heap
+    ///
+    /// **Time Complexity**: O(1) amortized
+    ///
+    /// **Algorithm**:
+    /// 1. Create a new node with rank 0 (leaf node)
+    /// 2. Compare priority with current root
+    /// 3. If new priority is smaller, make new node the root (old root becomes child)
+    /// 4. Otherwise, add new node as a child of the root
+    /// 5. Update ranks to maintain rank constraints
+    ///
+    /// **Rank Update**: When a node becomes a parent, its rank is updated based on
+    /// its children's ranks. Rank = min(rank(w₁), rank(w₂)) + 1 where w₁, w₂ are
+    /// children with smallest ranks. This maintains the rank constraint invariant.
+    ///
+    /// **Invariant Maintenance**:
+    /// - Heap property: smaller priority becomes parent
+    /// - Rank constraints: ranks updated to satisfy rank(v) ≤ rank(w₁) + 1 and rank(v) ≤ rank(w₂) + 1
+    fn push_with_handle(&mut self, priority: P, item: T) -> Self::Handle {
+        // Create new node with rank 0 (leaf node, no children)
+        let node = Rc::new(RefCell::new(Node {
+            item,
+            priority,
+            parent: None,
+            child: None,
+            sibling: None,
+            rank: 0,       // Leaf nodes have rank 0
+            marked: false, // New nodes are unmarked
+        }));
+
+        // Link new node into the tree structure
+        if let Some(ref root) = self.root {
+            if node.borrow().priority < root.borrow().priority {
+                // Case 1: New node has smaller priority
+                // Make new node the root, old root becomes its child
+                // This maintains heap property: parent <= child
+                Self::make_child(&node, root);
+                // Update root pointer to new minimum
+                self.root = Some(Rc::clone(&node));
+            } else {
+                // Case 2: Current root has smaller or equal priority
+                // Add new node as a child of the root
+                // Heap property maintained: new node >= root
+                Self::make_child(root, &node);
+                // Root stays the same
+            }
+        } else {
+            // Empty heap: new node becomes root
+            self.root = Some(Rc::clone(&node));
+        }
+
+        self.len += 1;
+        RankPairingHandle {
+            node: Rc::downgrade(&node),
+        }
     }
 
     /// Decreases the priority of an element
@@ -392,54 +446,6 @@ impl<T, P: Ord> Heap<T, P> for RankPairingHeap<T, P> {
         // If heap property is not violated, no restructuring needed
 
         Ok(())
-    }
-
-    /// Merges another heap into this heap
-    ///
-    /// **Time Complexity**: O(1) amortized
-    ///
-    /// **Algorithm**:
-    /// 1. Compare roots of both heaps
-    /// 2. Make the larger-priority root a child of the smaller-priority root
-    /// 3. Update ranks to maintain rank constraints
-    /// 4. The smaller root becomes the new root
-    ///
-    /// This is trivially O(1): we only need one comparison and a few pointer updates.
-    /// The rank update is O(1) because we're just adding one child.
-    ///
-    /// **Post-condition**: After merge, `other` is empty (consumed by this heap)
-    fn merge(&mut self, mut other: Self) {
-        // Empty heaps are easy cases
-        if other.is_empty() {
-            return; // Nothing to merge
-        }
-
-        if self.is_empty() {
-            // This heap is empty: just take the other heap
-            *self = other;
-            return;
-        }
-
-        // Both heaps are non-empty: need to link them
-        let self_root = self.root.take().unwrap();
-        let other_root = other.root.take().unwrap();
-
-        // Compare roots: smaller priority becomes parent (heap property)
-        if other_root.borrow().priority < self_root.borrow().priority {
-            // Other root has smaller priority: it becomes the new root
-            // Self root becomes a child of other root
-            Self::make_child(&other_root, &self_root);
-            self.root = Some(other_root);
-        } else {
-            // Self root has smaller or equal priority: it stays root
-            // Other root becomes a child of self root
-            Self::make_child(&self_root, &other_root);
-            self.root = Some(self_root);
-        }
-
-        // Update length and mark other as empty (prevent double-free)
-        self.len += other.len;
-        other.len = 0;
     }
 }
 

--- a/src/simple_binary.rs
+++ b/src/simple_binary.rs
@@ -1,0 +1,236 @@
+//! Simple Binary Heap implementation
+//!
+//! A straightforward binary min-heap implementation that only implements
+//! the base [`Heap`] trait without `decrease_key` support.
+//!
+//! This is provided as a simpler alternative when you don't need `decrease_key`
+//! operations. For algorithms requiring priority updates (like Dijkstra's),
+//! use one of the advanced heaps like [`FibonacciHeap`](crate::fibonacci::FibonacciHeap).
+//!
+//! # Time Complexity
+//!
+//! | Operation | Complexity |
+//! |-----------|------------|
+//! | `push`    | O(log n)   |
+//! | `pop`     | O(log n)   |
+//! | `peek`    | O(1)       |
+//! | `merge`   | O(n log n) |
+//!
+//! # Example
+//!
+//! ```rust
+//! use rust_advanced_heaps::Heap;
+//! use rust_advanced_heaps::simple_binary::SimpleBinaryHeap;
+//!
+//! let mut heap = SimpleBinaryHeap::new();
+//! heap.push(3, "three");
+//! heap.push(1, "one");
+//! heap.push(2, "two");
+//!
+//! assert_eq!(heap.peek(), Some((&1, &"one")));
+//! assert_eq!(heap.pop(), Some((1, "one")));
+//! assert_eq!(heap.pop(), Some((2, "two")));
+//! assert_eq!(heap.pop(), Some((3, "three")));
+//! assert_eq!(heap.pop(), None);
+//! ```
+
+use crate::traits::Heap;
+
+/// A simple binary min-heap
+///
+/// This heap stores (priority, item) pairs and always returns the element
+/// with the minimum priority first.
+///
+/// Unlike the advanced heaps in this crate, `SimpleBinaryHeap` does not
+/// support `decrease_key` operations. If you need to update priorities
+/// of elements already in the heap, use [`FibonacciHeap`](crate::fibonacci::FibonacciHeap)
+/// or another advanced heap implementation.
+#[derive(Debug)]
+pub struct SimpleBinaryHeap<T, P: Ord> {
+    /// The heap data stored as a vector of (priority, item) pairs
+    data: Vec<(P, T)>,
+}
+
+impl<T, P: Ord> Heap<T, P> for SimpleBinaryHeap<T, P> {
+    fn new() -> Self {
+        Self { data: Vec::new() }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    fn push(&mut self, priority: P, item: T) {
+        self.data.push((priority, item));
+        self.sift_up(self.data.len() - 1);
+    }
+
+    fn peek(&self) -> Option<(&P, &T)> {
+        self.data.first().map(|(p, t)| (p, t))
+    }
+
+    fn pop(&mut self) -> Option<(P, T)> {
+        if self.data.is_empty() {
+            return None;
+        }
+
+        let last_idx = self.data.len() - 1;
+        self.data.swap(0, last_idx);
+        let result = self.data.pop();
+
+        if !self.data.is_empty() {
+            self.sift_down(0);
+        }
+
+        result
+    }
+
+    fn merge(&mut self, other: Self) {
+        // Simple merge: push all elements and let sift_up handle ordering
+        // This is O(n log n) but could be optimized to O(n) with heapify
+        for (priority, item) in other.data {
+            self.push(priority, item);
+        }
+    }
+}
+
+impl<T, P: Ord> SimpleBinaryHeap<T, P> {
+    /// Move element at index up to maintain heap property
+    fn sift_up(&mut self, mut index: usize) {
+        while index > 0 {
+            let parent = (index - 1) / 2;
+            if self.data[index].0 < self.data[parent].0 {
+                self.data.swap(index, parent);
+                index = parent;
+            } else {
+                break;
+            }
+        }
+    }
+
+    /// Move element at index down to maintain heap property
+    fn sift_down(&mut self, mut index: usize) {
+        let len = self.data.len();
+        loop {
+            let left = 2 * index + 1;
+            let right = 2 * index + 2;
+            let mut smallest = index;
+
+            if left < len && self.data[left].0 < self.data[smallest].0 {
+                smallest = left;
+            }
+            if right < len && self.data[right].0 < self.data[smallest].0 {
+                smallest = right;
+            }
+
+            if smallest != index {
+                self.data.swap(index, smallest);
+                index = smallest;
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+impl<T, P: Ord> Default for SimpleBinaryHeap<T, P> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_basic_operations() {
+        let mut heap = SimpleBinaryHeap::new();
+
+        assert!(heap.is_empty());
+        assert_eq!(heap.len(), 0);
+
+        heap.push(3, "three");
+        heap.push(1, "one");
+        heap.push(2, "two");
+
+        assert!(!heap.is_empty());
+        assert_eq!(heap.len(), 3);
+        assert_eq!(heap.peek(), Some((&1, &"one")));
+
+        assert_eq!(heap.pop(), Some((1, "one")));
+        assert_eq!(heap.pop(), Some((2, "two")));
+        assert_eq!(heap.pop(), Some((3, "three")));
+        assert_eq!(heap.pop(), None);
+    }
+
+    #[test]
+    fn test_duplicate_priorities() {
+        let mut heap = SimpleBinaryHeap::new();
+
+        heap.push(1, "a");
+        heap.push(1, "b");
+        heap.push(1, "c");
+
+        assert_eq!(heap.len(), 3);
+
+        // All three should pop with priority 1
+        let (p1, _) = heap.pop().unwrap();
+        let (p2, _) = heap.pop().unwrap();
+        let (p3, _) = heap.pop().unwrap();
+
+        assert_eq!(p1, 1);
+        assert_eq!(p2, 1);
+        assert_eq!(p3, 1);
+    }
+
+    #[test]
+    fn test_merge() {
+        let mut heap1 = SimpleBinaryHeap::new();
+        let mut heap2 = SimpleBinaryHeap::new();
+
+        heap1.push(3, "three");
+        heap1.push(1, "one");
+
+        heap2.push(4, "four");
+        heap2.push(2, "two");
+
+        heap1.merge(heap2);
+
+        assert_eq!(heap1.len(), 4);
+        assert_eq!(heap1.pop(), Some((1, "one")));
+        assert_eq!(heap1.pop(), Some((2, "two")));
+        assert_eq!(heap1.pop(), Some((3, "three")));
+        assert_eq!(heap1.pop(), Some((4, "four")));
+    }
+
+    #[test]
+    fn test_ascending_insertion() {
+        let mut heap = SimpleBinaryHeap::new();
+
+        for i in 0..100 {
+            heap.push(i, i);
+        }
+
+        for i in 0..100 {
+            assert_eq!(heap.pop(), Some((i, i)));
+        }
+    }
+
+    #[test]
+    fn test_descending_insertion() {
+        let mut heap = SimpleBinaryHeap::new();
+
+        for i in (0..100).rev() {
+            heap.push(i, i);
+        }
+
+        for i in 0..100 {
+            assert_eq!(heap.pop(), Some((i, i)));
+        }
+    }
+}

--- a/src/stdlib_compat.rs
+++ b/src/stdlib_compat.rs
@@ -1,51 +1,43 @@
 //! Standard library compatibility layer
 //!
-//! Provides a drop-in replacement for `std::collections::BinaryHeap`
-//! that supports `decrease_key` operations.
+//! Provides a drop-in replacement for `std::collections::BinaryHeap`.
 //!
 //! # Differences from BinaryHeap
 //!
 //! - **Min-heap vs Max-heap**: This is a min-heap, while `BinaryHeap` is a max-heap.
 //!   Use `std::cmp::Reverse<T>` to get max-heap behavior.
-//! - **decrease_key support**: Unlike `BinaryHeap`, this supports efficient `decrease_key`
-//!   operations via handles.
 //!
 //! # Example
 //!
 //! ```rust
 //! use rust_advanced_heaps::stdlib_compat::StdHeap;
-//! use rust_advanced_heaps::fibonacci::FibonacciHeap;
+//! use rust_advanced_heaps::simple_binary::SimpleBinaryHeap;
 //!
 //! // Use like std::collections::BinaryHeap
-//! let mut heap: StdHeap<i32, FibonacciHeap<(), i32>> = StdHeap::new();
+//! let mut heap: StdHeap<i32, SimpleBinaryHeap<(), i32>> = StdHeap::new();
 //! heap.push(5);
 //! heap.push(3);
 //! heap.push(7);
 //! assert_eq!(heap.peek(), Some(&3)); // min-heap, unlike BinaryHeap's max-heap
 //! assert_eq!(heap.pop(), Some(3));
-//!
-//! // But with decrease_key support!
-//! let handle = heap.push_with_handle(10);
-//! heap.decrease_key(&handle.0, 1);
-//! assert_eq!(heap.peek(), Some(&1));
 //! ```
 
-use crate::Heap;
+use crate::traits::Heap;
 
-/// A drop-in replacement for `std::collections::BinaryHeap` with `decrease_key` support
+/// A drop-in replacement for `std::collections::BinaryHeap`
 ///
 /// When the item type `T` implements `Ord`, you can use this wrapper to get
 /// a `BinaryHeap`-like API where the item itself serves as the priority.
 ///
 /// # Type Parameters
-/// - `T`: The item type, must implement `Ord` and `Clone` (for handles)
-/// - `H`: The underlying heap implementation (e.g., `FibonacciHeap<(), T>`)
-pub struct StdHeap<T: Ord + Clone, H: Heap<(), T>> {
+/// - `T`: The item type, must implement `Ord`
+/// - `H`: The underlying heap implementation (e.g., `SimpleBinaryHeap<(), T>`)
+pub struct StdHeap<T: Ord, H: Heap<(), T>> {
     heap: H,
     _phantom: std::marker::PhantomData<T>,
 }
 
-impl<T: Ord + Clone, H: Heap<(), T>> StdHeap<T, H> {
+impl<T: Ord, H: Heap<(), T>> StdHeap<T, H> {
     /// Creates a new empty heap
     pub fn new() -> Self {
         Self {
@@ -67,19 +59,8 @@ impl<T: Ord + Clone, H: Heap<(), T>> StdHeap<T, H> {
     /// Pushes an item onto the heap
     ///
     /// The item itself serves as the priority.
-    ///
-    /// Returns a handle that can be used with `decrease_key`. If you don't need
-    /// `decrease_key`, you can ignore the return value.
-    pub fn push(&mut self, item: T) -> H::Handle {
+    pub fn push(&mut self, item: T) {
         self.heap.push(item, ())
-    }
-
-    /// Pushes an item and returns both a handle and the item
-    ///
-    /// Useful when you need to store the handle for later `decrease_key` operations.
-    pub fn push_with_handle(&mut self, item: T) -> (H::Handle, T) {
-        let handle = self.push(item.clone());
-        (handle, item)
     }
 
     /// Returns a reference to the smallest item without removing it
@@ -95,24 +76,9 @@ impl<T: Ord + Clone, H: Heap<(), T>> StdHeap<T, H> {
     pub fn pop(&mut self) -> Option<T> {
         self.heap.pop().map(|(priority, _)| priority)
     }
-
-    /// Decreases the priority of an item identified by the handle
-    ///
-    /// This operation is not available in `BinaryHeap`.
-    ///
-    /// # Safety
-    /// The handle must be valid (from a previous `push` and not yet popped).
-    /// The new priority must be less than the current priority.
-    pub fn decrease_key(
-        &mut self,
-        handle: &H::Handle,
-        new_priority: T,
-    ) -> Result<(), crate::traits::HeapError> {
-        self.heap.decrease_key(handle, new_priority)
-    }
 }
 
-impl<T: Ord + Clone, H: Heap<(), T>> Default for StdHeap<T, H> {
+impl<T: Ord, H: Heap<(), T>> Default for StdHeap<T, H> {
     fn default() -> Self {
         Self::new()
     }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -1,7 +1,13 @@
 //! Common traits for heap data structures
 //!
-//! This module provides traits compatible with Rust's standard heap API while
-//! adding support for efficient `decrease_key` operations.
+//! This module provides a two-tier trait hierarchy for heap/priority queue data structures:
+//!
+//! - [`Heap`]: Base trait for simple heaps without `decrease_key` support
+//! - [`DecreaseKeyHeap`]: Extended trait adding `decrease_key` and handle-based operations
+//!
+//! The base [`Heap`] trait is compatible with Rust's standard heap API patterns,
+//! while [`DecreaseKeyHeap`] adds the advanced operations needed for algorithms
+//! like Dijkstra's shortest path.
 
 use std::fmt;
 
@@ -38,20 +44,33 @@ impl std::error::Error for HeapError {}
 /// the underlying implementation (e.g., reference-counted vs raw pointer).
 pub trait Handle: Clone + PartialEq + Eq {}
 
-/// Common operations for heap/priority queue data structures
+/// Base trait for heap/priority queue data structures
 ///
-/// This trait provides an API similar to Rust's `BinaryHeap`, with the addition
-/// of `decrease_key` support. All methods follow standard Rust naming conventions:
-/// - `push` (standard Rust heap method)
-/// - `pop` (standard Rust heap method)
-/// - `peek` (standard Rust heap method)
+/// This trait provides a simple API similar to Rust's `BinaryHeap`:
+/// - `push` inserts an element (returns `()`)
+/// - `pop` removes and returns the minimum
+/// - `peek` returns the minimum without removing it
 ///
 /// Unlike `BinaryHeap` which stores values directly (using `Ord`), these heaps
-/// store (priority, item) pairs to support efficient `decrease_key` operations.
+/// store (priority, item) pairs to separate the ordering key from the data.
+///
+/// For heaps that support `decrease_key` operations, see [`DecreaseKeyHeap`].
+///
+/// # Example
+///
+/// ```rust
+/// use rust_advanced_heaps::Heap;
+/// use rust_advanced_heaps::simple_binary::SimpleBinaryHeap;
+///
+/// let mut heap = SimpleBinaryHeap::new();
+/// heap.push(3, "three");
+/// heap.push(1, "one");
+/// heap.push(2, "two");
+///
+/// assert_eq!(heap.peek(), Some((&1, &"one")));
+/// assert_eq!(heap.pop(), Some((1, "one")));
+/// ```
 pub trait Heap<T, P: Ord> {
-    /// The handle type for this heap, used to reference elements for decrease_key
-    type Handle: Handle;
-
     /// Creates a new empty heap
     fn new() -> Self;
 
@@ -60,6 +79,59 @@ pub trait Heap<T, P: Ord> {
 
     /// Returns the number of elements in the heap
     fn len(&self) -> usize;
+
+    /// Inserts an element with the given priority
+    ///
+    /// # Time Complexity
+    /// Typically O(log n) for simple heaps, O(1) amortized for advanced heaps.
+    fn push(&mut self, priority: P, item: T);
+
+    /// Returns the minimum priority and associated item without removing it
+    ///
+    /// Note that `BinaryHeap` is a max-heap, while these heaps are min-heaps.
+    ///
+    /// # Time Complexity
+    /// O(1) for all implementations
+    fn peek(&self) -> Option<(&P, &T)>;
+
+    /// Removes and returns the minimum priority and associated item
+    ///
+    /// Note that `BinaryHeap` is a max-heap, while these heaps are min-heaps.
+    ///
+    /// # Time Complexity
+    /// Typically O(log n) for all implementations.
+    fn pop(&mut self) -> Option<(P, T)>;
+
+    /// Merges another heap into this one, consuming the other heap
+    ///
+    /// # Time Complexity
+    /// Varies by implementation: O(1) for Fibonacci/Pairing heaps, O(log n) for Binomial.
+    fn merge(&mut self, other: Self);
+}
+
+/// Extended heap trait with `decrease_key` support
+///
+/// This trait extends [`Heap`] with operations that require tracking element handles:
+/// - `push_with_handle` returns a handle that can be used with `decrease_key`
+/// - `decrease_key` efficiently updates an element's priority
+///
+/// These operations are essential for algorithms like Dijkstra's shortest path
+/// that need to update priorities of elements already in the heap.
+///
+/// # Example
+///
+/// ```rust
+/// use rust_advanced_heaps::{Heap, DecreaseKeyHeap};
+/// use rust_advanced_heaps::fibonacci::FibonacciHeap;
+///
+/// let mut heap = FibonacciHeap::new();
+/// let handle = heap.push_with_handle(10, "item");
+/// heap.decrease_key(&handle, 5).unwrap();
+/// assert_eq!(heap.peek(), Some((&5, &"item")));
+/// ```
+pub trait DecreaseKeyHeap<T, P: Ord>: Heap<T, P> {
+    /// The handle type for this heap, used to reference elements for decrease_key
+    type Handle: Handle;
 
     /// Inserts an element with the given priority, returning a handle
     ///
@@ -70,38 +142,7 @@ pub trait Heap<T, P: Ord> {
     /// - Pairing Heap: O(1) amortized
     /// - Rank-Pairing Heap: O(1) amortized
     /// - Binomial Heap: O(log n)
-    fn push(&mut self, priority: P, item: T) -> Self::Handle;
-
-    /// Returns the minimum priority and associated item without removing it
-    ///
-    /// Note that `BinaryHeap` is a max-heap, while these heaps are min-heaps.
-    ///
-    /// # Lifetime Safety
-    ///
-    /// The returned references are valid for the lifetime of the `&self` borrow.
-    /// This is safe because:
-    /// - The caller holds `&self`, preventing any `&mut self` methods from being called
-    /// - All mutating operations (`push`, `pop`, `decrease_key`, `merge`) require `&mut self`
-    /// - Therefore no internal mutation can occur while these references exist
-    ///
-    /// Implementations using interior mutability (e.g., `RefCell`) may use unsafe
-    /// pointer operations to return these references, but this is sound because
-    /// the `&self` borrow prevents any mutable access to the heap structure.
-    ///
-    /// # Time Complexity
-    /// All implementations: O(1)
-    fn peek(&self) -> Option<(&P, &T)>;
-
-    /// Removes and returns the minimum priority and associated item
-    ///
-    /// Note that `BinaryHeap` is a max-heap, while these heaps are min-heaps.
-    ///
-    /// # Time Complexity
-    /// - Fibonacci Heap: O(log n) amortized
-    /// - Pairing Heap: O(log n) amortized
-    /// - Rank-Pairing Heap: O(log n) amortized
-    /// - Binomial Heap: O(log n)
-    fn pop(&mut self) -> Option<(P, T)>;
+    fn push_with_handle(&mut self, priority: P, item: T) -> Self::Handle;
 
     /// Decreases the priority of an element identified by the handle
     ///
@@ -110,8 +151,8 @@ pub trait Heap<T, P: Ord> {
     /// like Dijkstra's shortest path.
     ///
     /// # Safety
-    /// The handle must be valid (from a previous `push` and not yet popped).
-    /// Behavior is undefined if the handle is invalid.
+    /// The handle must be valid (from a previous `push_with_handle` and not yet popped).
+    /// Returns an error if the handle is invalid.
     ///
     /// # Errors
     /// Returns `HeapError::PriorityNotDecreased` if the new priority is not
@@ -123,13 +164,4 @@ pub trait Heap<T, P: Ord> {
     /// - Rank-Pairing Heap: O(1) amortized
     /// - Binomial Heap: O(log n)
     fn decrease_key(&mut self, handle: &Self::Handle, new_priority: P) -> Result<(), HeapError>;
-
-    /// Merges another heap into this one, consuming the other heap
-    ///
-    /// # Time Complexity
-    /// - Fibonacci Heap: O(1)
-    /// - Pairing Heap: O(1)
-    /// - Rank-Pairing Heap: O(1)
-    /// - Binomial Heap: O(log n)
-    fn merge(&mut self, other: Self);
 }

--- a/tests/big_o_proofs.rs
+++ b/tests/big_o_proofs.rs
@@ -21,7 +21,7 @@ use rust_advanced_heaps::rank_pairing::RankPairingHeap;
 use rust_advanced_heaps::skew_binomial::SkewBinomialHeap;
 use rust_advanced_heaps::strict_fibonacci::StrictFibonacciHeap;
 use rust_advanced_heaps::twothree::TwoThreeHeap;
-use rust_advanced_heaps::Heap;
+use rust_advanced_heaps::{DecreaseKeyHeap, Heap};
 
 use ctor::ctor;
 use parking_lot::RwLock;
@@ -123,7 +123,7 @@ fn test_pop_batch_complexity<H: Heap<i32, i32>>(heap_name: &str) {
 /// - O(1) worst-case: Brodal -> O(n) batch
 /// - o(log n) amortized: Pairing -> O(n) batch (sub-logarithmic, better than O(log n))
 /// - O(log n) worst-case: Binomial, SkewBinomial -> O(n log n) batch
-fn test_decrease_key_batch_complexity<H: Heap<i32, i32>>(
+fn test_decrease_key_batch_complexity<H: DecreaseKeyHeap<i32, i32>>(
     heap_name: &str,
     batch_expected: BigOAlgorithmComplexity,
 ) {
@@ -148,7 +148,7 @@ fn test_decrease_key_batch_complexity<H: Heap<i32, i32>>(
                 let mut h = heap1.write();
                 // Insert elements with high priorities
                 for i in 0..1000 {
-                    handles.push(h.push(i + 10000, i));
+                    handles.push(h.push_with_handle(i + 10000, i));
                 }
             }
 
@@ -165,7 +165,7 @@ fn test_decrease_key_batch_complexity<H: Heap<i32, i32>>(
             {
                 let mut h = heap2.write();
                 for i in 0..2000 {
-                    handles.push(h.push(i + 20000, i));
+                    handles.push(h.push_with_handle(i + 20000, i));
                 }
             }
 

--- a/tests/generic_heap_tests.rs
+++ b/tests/generic_heap_tests.rs
@@ -2,1073 +2,699 @@
 //!
 //! These tests work with any Heap implementation and stress the trait interface
 //! with various edge cases and complex scenarios.
+//!
+//! Test organization:
+//! - Base `Heap` trait tests: Applied to ALL heaps including SimpleBinaryHeap
+//! - `DecreaseKeyHeap` trait tests: Applied only to heaps with decrease_key support
 
-use rust_advanced_heaps::binomial::BinomialHeap;
-use rust_advanced_heaps::fibonacci::FibonacciHeap;
-use rust_advanced_heaps::pairing::PairingHeap;
-use rust_advanced_heaps::rank_pairing::RankPairingHeap;
-use rust_advanced_heaps::skew_binomial::SkewBinomialHeap;
-use rust_advanced_heaps::strict_fibonacci::StrictFibonacciHeap;
 use rust_advanced_heaps::traits::HeapError;
-use rust_advanced_heaps::twothree::TwoThreeHeap;
-use rust_advanced_heaps::Heap;
-
-// Test helpers that work with any Heap implementation
-
-/// Test that empty heap behaves correctly
-fn test_empty_heap<H: Heap<String, i32>>() {
-    let mut heap = H::new();
-    assert!(heap.is_empty());
-    assert_eq!(heap.len(), 0);
-    assert_eq!(heap.peek(), None);
-    assert_eq!(heap.pop(), None);
-}
-
-/// Test basic insert and pop operations
-fn test_basic_operations<H: Heap<&'static str, i32>>() {
-    let mut heap = H::new();
-
-    // Insert some elements
-    let _h1 = heap.push(5, "five");
-    let _h2 = heap.push(1, "one");
-    let _h3 = heap.push(10, "ten");
-    let _h4 = heap.push(3, "three");
-
-    assert!(!heap.is_empty());
-    assert_eq!(heap.len(), 4);
-
-    // Peek should return minimum
-    let min = heap.peek();
-    assert_eq!(min, Some((&1, &"one")));
-
-    // Pop should return minimums in order
-    assert_eq!(heap.pop(), Some((1, "one")));
-    assert_eq!(heap.pop(), Some((3, "three")));
-    assert_eq!(heap.pop(), Some((5, "five")));
-    assert_eq!(heap.pop(), Some((10, "ten")));
-    assert_eq!(heap.pop(), None);
-    assert!(heap.is_empty());
-}
-
-/// Test decrease_key operations extensively
-fn test_decrease_key_operations<H: Heap<i32, i32>>() {
-    let mut heap = H::new();
-
-    // Insert elements
-    let _h1 = heap.push(100, 1);
-    let h2 = heap.push(200, 2);
-    let _h3 = heap.push(300, 3);
-    let h4 = heap.push(400, 4);
-
-    // Verify initial min
-    assert_eq!(heap.peek(), Some((&100, &1)));
-
-    // Decrease key of element not at min
-    assert!(heap.decrease_key(&h2, 50).is_ok());
-    assert_eq!(heap.peek(), Some((&50, &2)));
-
-    // Decrease key to become new min
-    assert!(heap.decrease_key(&h4, 25).is_ok());
-    assert_eq!(heap.peek(), Some((&25, &4)));
-
-    // Decrease key of current min even more
-    assert!(heap.decrease_key(&h4, 1).is_ok());
-    assert_eq!(heap.peek(), Some((&1, &4)));
-
-    // Pop and verify order
-    assert_eq!(heap.pop(), Some((1, 4)));
-    assert_eq!(heap.pop(), Some((50, 2)));
-    assert_eq!(heap.pop(), Some((100, 1)));
-    assert_eq!(heap.pop(), Some((300, 3)));
-}
-
-/// Test decrease_key on multiple elements
-fn test_multiple_decrease_keys<H: Heap<i32, i32>>() {
-    let mut heap = H::new();
-    let mut handles = Vec::new();
-
-    // Insert 20 elements with high priorities
-    for i in 0..20 {
-        handles.push(heap.push((i + 1) * 100, i));
-    }
-
-    // Decrease all keys to be much smaller
-    for (i, handle) in handles.iter().enumerate() {
-        assert!(heap.decrease_key(handle, i as i32).is_ok());
-    }
-
-    // Verify heap property maintained
-    let min = heap.peek();
-    assert_eq!(min, Some((&0, &0)));
-
-    // Pop all and verify ascending order
-    for i in 0..20 {
-        let popped = heap.pop();
-        assert_eq!(popped, Some((i, i)));
-    }
-    assert!(heap.is_empty());
-}
-
-/// Test merge operations
-fn test_merge_operations<H: Heap<&'static str, i32>>() {
-    let mut heap1 = H::new();
-    heap1.push(5, "five");
-    heap1.push(1, "one");
-
-    let mut heap2 = H::new();
-    heap2.push(10, "ten");
-    heap2.push(3, "three");
-
-    // Merge heaps
-    heap1.merge(heap2);
-
-    assert_eq!(heap1.len(), 4);
-    assert_eq!(heap1.peek(), Some((&1, &"one")));
-
-    // Verify all elements can be popped in order
-    assert_eq!(heap1.pop(), Some((1, "one")));
-    assert_eq!(heap1.pop(), Some((3, "three")));
-    assert_eq!(heap1.pop(), Some((5, "five")));
-    assert_eq!(heap1.pop(), Some((10, "ten")));
-}
-
-/// Test merge with empty heap
-fn test_merge_empty<H: Heap<i32, i32>>() {
-    let mut heap1 = H::new();
-    heap1.push(5, 1);
-    heap1.push(1, 2);
-
-    let heap2 = H::new();
-
-    let len_before = heap1.len();
-    heap1.merge(heap2);
-    assert_eq!(heap1.len(), len_before);
-
-    // Merge empty into non-empty
-    let mut heap3 = H::new();
-    let mut heap4 = H::new();
-    heap4.push(3, 3);
-
-    heap3.merge(heap4);
-    assert_eq!(heap3.len(), 1);
-    assert_eq!(heap3.peek(), Some((&3, &3)));
-}
-
-/// Test with duplicate priorities
-fn test_duplicate_priorities<H: Heap<&'static str, i32>>() {
-    let mut heap = H::new();
-
-    heap.push(5, "a");
-    heap.push(5, "b");
-    heap.push(5, "c");
-    heap.push(1, "d");
-
-    // All items with priority 5 should come after priority 1
-    assert_eq!(heap.pop(), Some((1, "d")));
-
-    // Items with same priority can come in any order
-    let mut seen = std::collections::HashSet::new();
-    for _ in 0..3 {
-        if let Some((pri, item)) = heap.pop() {
-            assert_eq!(pri, 5);
-            assert!(seen.insert(item));
-        }
-    }
-    assert_eq!(seen.len(), 3);
-}
-
-/// Test decrease_key after pop (should panic or handle gracefully)
-#[allow(dead_code)]
-fn test_decrease_key_after_pop<H: Heap<i32, i32>>() {
-    let mut heap = H::new();
-    let _handle = heap.push(10, 1);
-
-    // Pop the element
-    heap.pop();
-
-    // Attempting decrease_key on popped handle is undefined behavior
-    // We can't really test this without unsafe code, but we document it
-}
-
-/// Test many operations in sequence
-fn test_stress_operations<H: Heap<i32, i32>>() {
-    let mut heap = H::new();
-    let mut handles = Vec::new();
-
-    // Insert many elements
-    for i in 0..100 {
-        handles.push(heap.push(i * 2, i));
-    }
-
-    // Random decrease_key operations
-    for i in (0..100).step_by(3) {
-        assert!(heap.decrease_key(&handles[i], i as i32 * 2 - 1).is_ok());
-    }
-
-    // Pop some elements
-    for _ in 0..20 {
-        heap.pop();
-    }
-
-    // Verify heap still works
-    assert!(!heap.is_empty());
-    assert!(heap.peek().is_some());
-
-    // Pop remaining
-    let mut count = 0;
-    while heap.pop().is_some() {
-        count += 1;
-    }
-    assert_eq!(count, 80); // 100 - 20 = 80 remaining
-}
-
-/// Test that peek doesn't modify heap
-fn test_peek_idempotent<H: Heap<&'static str, i32>>() {
-    let mut heap = H::new();
-    heap.push(5, "five");
-    heap.push(1, "one");
-
-    // Peek multiple times should return same result
-    assert_eq!(heap.peek(), Some((&1, &"one")));
-    assert_eq!(heap.peek(), Some((&1, &"one")));
-    assert_eq!(heap.peek(), Some((&1, &"one")));
-
-    // Length shouldn't change
-    assert_eq!(heap.len(), 2);
-
-    // Pop should still work
-    assert_eq!(heap.pop(), Some((1, "one")));
-}
-
-/// Test single element heap
-fn test_single_element<H: Heap<&'static str, i32>>() {
-    let mut heap = H::new();
-    let handle = heap.push(42, "single");
-
-    assert_eq!(heap.len(), 1);
-    assert_eq!(heap.peek(), Some((&42, &"single")));
-
-    // Decrease key
-    assert!(heap.decrease_key(&handle, 10).is_ok());
-    assert_eq!(heap.peek(), Some((&10, &"single")));
-
-    // Pop
-    assert_eq!(heap.pop(), Some((10, "single")));
-    assert!(heap.is_empty());
-}
-
-/// Test merge then operations
-fn test_merge_then_operations<H: Heap<i32, i32>>() {
-    let mut heap1 = H::new();
-    for i in 0..10 {
-        heap1.push(i * 10, i);
-    }
-
-    let mut heap2 = H::new();
-    for i in 10..20 {
-        heap2.push(i * 10, i);
-    }
-
-    heap1.merge(heap2);
-
-    // After merge, should be able to decrease keys
-    // (Can't test this without handles, but merge should work)
-
-    // Pop all elements
-    let mut count = 0;
-    let mut last_priority = i32::MIN;
-    while let Some((priority, _)) = heap1.pop() {
-        assert!(priority >= last_priority); // Should be non-decreasing
-        last_priority = priority;
-        count += 1;
-    }
-    assert_eq!(count, 20);
-}
-
-/// Test rapid insert and pop
-fn test_rapid_operations<H: Heap<i32, i32>>() {
-    let mut heap = H::new();
-
-    // Rapid insert-pop cycle
-    for i in 0..50 {
-        heap.push(i, i);
-        if i % 3 == 0 {
-            heap.pop();
-        }
-    }
-
-    // Verify heap still works
-    assert!(!heap.is_empty());
-
-    // Pop remaining
-    let mut count = 0;
-    while heap.pop().is_some() {
-        count += 1;
-    }
-    assert!(count > 0);
-}
-
-/// Test with large priorities
-fn test_large_priorities<H: Heap<i32, i64>>() {
-    let mut heap = H::new();
-
-    heap.push(1_000_000_000, 1);
-    heap.push(2_000_000_000, 2);
-    heap.push(-1_000_000_000, 3);
-
-    assert_eq!(heap.peek(), Some((&-1_000_000_000, &3)));
-    assert_eq!(heap.pop(), Some((-1_000_000_000, 3)));
-    assert_eq!(heap.pop(), Some((1_000_000_000, 1)));
-    assert_eq!(heap.pop(), Some((2_000_000_000, 2)));
-}
-
-/// Test decrease_key to same priority (edge case)
-fn test_decrease_key_same<H: Heap<i32, i32>>() {
-    let mut heap = H::new();
-    let handle = heap.push(10, 1);
-
-    // Decrease to same priority (should return error)
-    assert_eq!(
-        heap.decrease_key(&handle, 10),
-        Err(HeapError::PriorityNotDecreased)
-    );
-
-    // Should still be min
-    assert_eq!(heap.peek(), Some((&10, &1)));
-}
-
-/// Test complex sequence of operations
-fn test_complex_sequence<H: Heap<String, i32>>() {
-    let mut heap = H::new();
-    let mut handles = Vec::new();
-
-    // Insert with gaps
-    for i in 0..20 {
-        if i % 2 == 0 {
-            handles.push(heap.push(i * 10, format!("item{}", i)));
-        }
-    }
-
-    // Decrease some keys (but skip first few to avoid issues)
-    for (i, handle) in handles.iter().enumerate().skip(3).step_by(3) {
-        let new_priority = (i as i32 * 5).max(1); // Ensure positive priority
-        if new_priority < i as i32 * 10 {
-            assert!(heap.decrease_key(handle, new_priority).is_ok());
-        }
-    }
-
-    // Pop some (but not all)
-    for _ in 0..3 {
-        if heap.pop().is_none() {
-            break;
-        }
-    }
-
-    // Insert more
-    for i in 20..25 {
-        heap.push(i * 10, format!("new{}", i));
-    }
-
-    // Verify still works
-    assert!(!heap.is_empty());
-    let min = heap.peek();
-    assert!(min.is_some());
-
-    // Pop all remaining (carefully)
-    let mut count = 0;
-    while heap.pop().is_some() {
-        count += 1;
-        if count > 50 {
-            // Safety limit
-            break;
-        }
-    }
-
-    // Final state check
-    assert!(heap.is_empty() || heap.peek().is_some());
-}
-
-/// Test ascending order insertion
-fn test_ascending_insertion<H: Heap<i32, i32>>() {
-    let mut heap = H::new();
-
-    // Insert in ascending order
-    for i in 0..50 {
-        heap.push(i, i);
-    }
-
-    // Should pop in ascending order
-    for i in 0..50 {
-        assert_eq!(heap.pop(), Some((i, i)));
-    }
-}
-
-/// Test descending order insertion
-fn test_descending_insertion<H: Heap<i32, i32>>() {
-    let mut heap = H::new();
-
-    // Insert in descending order
-    for i in (0..50).rev() {
-        heap.push(i, i);
-    }
-
-    // Should pop in ascending order (min heap)
-    for i in 0..50 {
-        assert_eq!(heap.pop(), Some((i, i)));
-    }
-}
-
-/// Test random order insertion
-fn test_random_order_insertion<H: Heap<i32, i32>>() {
-    let mut heap = H::new();
-    let mut values: Vec<i32> = (0..100).collect();
-    // Shuffle by swapping pairs
-    for i in (0..values.len()).step_by(7) {
-        if i + 1 < values.len() {
-            values.swap(i, i + 1);
-        }
-    }
-
-    for &val in &values {
-        heap.push(val * 2, val);
-    }
-
-    // Should pop in ascending order
-    for i in 0..100 {
-        assert_eq!(heap.pop(), Some((i * 2, i)));
-    }
-}
-
-/// Test multiple decrease_keys on same element
-fn test_multiple_decrease_same<H: Heap<i32, i32>>() {
-    let mut heap = H::new();
-    let handle = heap.push(1000, 1);
-
-    assert!(heap.decrease_key(&handle, 500).is_ok());
-    assert_eq!(heap.peek(), Some((&500, &1)));
-
-    assert!(heap.decrease_key(&handle, 250).is_ok());
-    assert_eq!(heap.peek(), Some((&250, &1)));
-
-    assert!(heap.decrease_key(&handle, 100).is_ok());
-    assert_eq!(heap.peek(), Some((&100, &1)));
-
-    assert!(heap.decrease_key(&handle, 50).is_ok());
-    assert_eq!(heap.peek(), Some((&50, &1)));
-
-    assert!(heap.decrease_key(&handle, 1).is_ok());
-    assert_eq!(heap.peek(), Some((&1, &1)));
-}
-
-/// Test decrease_key making element new min repeatedly
-fn test_decrease_key_new_min<H: Heap<i32, i32>>() {
-    let mut heap = H::new();
-    let h1 = heap.push(100, 1);
-    let h2 = heap.push(200, 2);
-    let h3 = heap.push(300, 3);
-
-    // Each decrease_key should make element new min
-    assert!(heap.decrease_key(&h3, 150).is_ok());
-    assert_eq!(heap.peek(), Some((&100, &1))); // Still h1
-
-    assert!(heap.decrease_key(&h2, 50).is_ok());
-    assert_eq!(heap.peek(), Some((&50, &2))); // Now h2
-
-    assert!(heap.decrease_key(&h1, 25).is_ok());
-    assert_eq!(heap.peek(), Some((&25, &1))); // Now h1
-}
-
-/// Test alternating insert and pop
-fn test_alternating_operations<H: Heap<i32, i32>>() {
-    let mut heap = H::new();
-
-    // Insert 5, pop 2, insert 3, pop 1, etc.
-    for i in 0..10 {
-        heap.push(i * 10, i);
-    }
-
-    // Pop 3
-    heap.pop();
-    heap.pop();
-    heap.pop();
-
-    // Insert 5 more
-    for i in 10..15 {
-        heap.push(i * 10, i);
-    }
-
-    // Pop 2
-    heap.pop();
-    heap.pop();
-
-    // Verify still works
-    assert!(!heap.is_empty());
-    assert!(heap.peek().is_some());
-
-    // Pop all remaining
-    let mut count = 0;
-    while heap.pop().is_some() {
-        count += 1;
-    }
-    assert_eq!(count, 10); // 10 - 3 + 5 - 2 = 10
-}
-
-/// Test merge with many elements
-fn test_merge_large<H: Heap<i32, i32>>() {
-    let mut heap1 = H::new();
-    for i in 0..100 {
-        heap1.push(i * 2, i);
-    }
-
-    let mut heap2 = H::new();
-    for i in 100..200 {
-        heap2.push(i * 2, i);
-    }
-
-    heap1.merge(heap2);
-    assert_eq!(heap1.len(), 200);
-
-    // Pop all and verify order
-    let mut last = i32::MIN;
-    let mut count = 0;
-    while let Some((priority, _)) = heap1.pop() {
-        assert!(priority >= last);
-        last = priority;
-        count += 1;
-    }
-    assert_eq!(count, 200);
-}
-
-/// Test decrease_key on every other element
-fn test_decrease_key_selective<H: Heap<i32, i32>>() {
-    let mut heap = H::new();
-    let mut handles = Vec::new();
-
-    // Insert 30 elements
-    for i in 0..30 {
-        handles.push(heap.push((i + 1) * 100, i));
-    }
-
-    // Decrease keys of even-indexed elements
-    for (i, handle) in handles.iter().enumerate() {
-        if i % 2 == 0 {
-            assert!(heap.decrease_key(handle, i as i32 * 10).is_ok());
-        }
-    }
-
-    // Verify min is from even-indexed (decreased) elements
-    let min = heap.peek();
-    assert!(min.is_some());
-    let min_priority = min.unwrap().0;
-    assert!(*min_priority < 100); // Should be from decreased elements
-
-    // Pop and verify order
-    let mut last = i32::MIN;
-    while let Some((priority, _)) = heap.pop() {
-        assert!(priority >= last);
-        last = priority;
-    }
-}
-
-/// Test edge case: all elements same priority after decrease
-fn test_all_same_priority<H: Heap<i32, i32>>() {
-    let mut heap = H::new();
-    let mut handles = Vec::new();
-
-    // Insert 10 elements with different priorities
-    for i in 0..10 {
-        handles.push(heap.push((i + 1) * 10, i));
-    }
-
-    // Decrease all to same priority
-    for handle in &handles {
-        assert!(heap.decrease_key(handle, 5).is_ok());
-    }
-
-    // All should have priority 5
-    assert_eq!(heap.peek().unwrap().0, &5);
-
-    // Pop all - should get all items (order doesn't matter for same priority)
-    let mut seen = std::collections::HashSet::new();
-    while let Some((priority, item)) = heap.pop() {
-        assert_eq!(priority, 5);
-        assert!(seen.insert(item));
-    }
-    assert_eq!(seen.len(), 10);
-}
-
-/// Test negative priorities
-fn test_negative_priorities<H: Heap<i32, i32>>() {
-    let mut heap = H::new();
-
-    heap.push(-10, 1);
-    heap.push(10, 2);
-    heap.push(-5, 3);
-    heap.push(5, 4);
-
-    // Min should be -10
-    assert_eq!(heap.pop(), Some((-10, 1)));
-    assert_eq!(heap.pop(), Some((-5, 3)));
-    assert_eq!(heap.pop(), Some((5, 4)));
-    assert_eq!(heap.pop(), Some((10, 2)));
-}
-
-/// Test decrease_key to negative
-fn test_decrease_to_negative<H: Heap<i32, i32>>() {
-    let mut heap = H::new();
-    let h1 = heap.push(10, 1);
-    let _h2 = heap.push(20, 2);
-
-    assert!(heap.decrease_key(&h1, -5).is_ok());
-    assert_eq!(heap.peek(), Some((&-5, &1)));
-    assert_eq!(heap.pop(), Some((-5, 1)));
-}
-
-/// Test basic push/peek/pop cycle
-fn test_alias_methods<H: Heap<&'static str, i32>>() {
-    let mut heap = H::new();
-
-    // Test push
-    let _h = heap.push(5, "five");
-    assert_eq!(heap.len(), 1);
-
-    // Test peek
-    assert_eq!(heap.peek(), Some((&5, &"five")));
-
-    // Test pop
-    assert_eq!(heap.pop(), Some((5, "five")));
-    assert_eq!(heap.pop(), None); // Should be empty now
-}
-
-/// Test heap property maintained through operations
-fn test_heap_property<H: Heap<i32, i32>>() {
-    let mut heap = H::new();
-    let mut handles = Vec::new();
-
-    // Insert random priorities
-    for i in 0..50 {
-        handles.push(heap.push((i * 17 + 23) % 1000, i));
-    }
-
-    // Random decrease_keys
-    for i in (0..50).step_by(7) {
-        if let Some(handle) = handles.get(i) {
-            let current_min = heap.peek().unwrap().0;
-            let new_priority = (*current_min / 2).max(1);
-            assert!(heap.decrease_key(handle, new_priority).is_ok());
-        }
-    }
-
-    // Verify heap property: each pop should be >= previous
-    let mut last_priority = i32::MIN;
-    while let Some((priority, _)) = heap.pop() {
-        assert!(priority >= last_priority);
-        last_priority = priority;
-    }
-}
-
-/// Test merge with handles from both heaps
-fn test_merge_with_handles<H: Heap<i32, i32>>() {
-    let mut heap1 = H::new();
-    let h1 = heap1.push(100, 1);
-
-    let mut heap2 = H::new();
-    let h2 = heap2.push(200, 2);
-
-    heap1.merge(heap2);
-
-    // After merge, both handles should still be valid
-    assert!(heap1.decrease_key(&h1, 50).is_ok());
-    assert_eq!(heap1.peek(), Some((&50, &1)));
-
-    assert!(heap1.decrease_key(&h2, 25).is_ok());
-    assert_eq!(heap1.peek(), Some((&25, &2)));
-}
-
-/// Test very large number of operations
-fn test_very_large_sequence<H: Heap<i32, i32>>() {
-    let mut heap = H::new();
-    let mut handles = Vec::new();
-
-    // Insert 1000 elements
-    for i in 0..1000 {
-        handles.push(heap.push(i * 10, i));
-    }
-
-    // Decrease keys of every 10th element
-    // New priority must be less than original (i*10), so use (i-1) which is always < i*10
-    for i in (0..1000).step_by(10) {
-        assert!(heap.decrease_key(&handles[i], (i as i32) - 1).is_ok());
-    }
-
-    // Pop first 100
-    for _ in 0..100 {
-        heap.pop();
-    }
-
-    // Insert 200 more
-    for i in 1000..1200 {
-        heap.push(i * 10, i);
-    }
-
-    // Verify heap still works
-    assert!(!heap.is_empty());
-
-    // Pop all remaining
-    let mut count = 0;
-    while heap.pop().is_some() {
-        count += 1;
-    }
-    assert_eq!(count, 1100); // 1000 - 100 + 200 = 1100
-}
-
-/// Test with string items
-fn test_string_items<H: Heap<String, i32>>() {
-    let mut heap = H::new();
-
-    heap.push(3, "c".to_string());
-    heap.push(1, "a".to_string());
-    heap.push(2, "b".to_string());
-
-    assert_eq!(heap.peek().unwrap().1, "a");
-    assert_eq!(heap.pop().unwrap().1, "a");
-    assert_eq!(heap.pop().unwrap().1, "b");
-    assert_eq!(heap.pop().unwrap().1, "c");
-}
-
-/// Test with tuple items
-fn test_tuple_items<H: Heap<(i32, i32), i32>>() {
-    let mut heap = H::new();
-
-    heap.push(3, (3, 3));
-    heap.push(1, (1, 1));
-    heap.push(2, (2, 2));
-
-    assert_eq!(heap.pop(), Some((1, (1, 1))));
-    assert_eq!(heap.pop(), Some((2, (2, 2))));
-    assert_eq!(heap.pop(), Some((3, (3, 3))));
-}
-
-// Macro to generate a single test function
-macro_rules! heap_test {
-    ($name:ident, $heap:ty, $func:ident) => {
-        #[test]
-        fn $name() {
-            $func::<$heap>();
+use rust_advanced_heaps::{DecreaseKeyHeap, Heap};
+
+// ============================================================================
+// Base Heap trait tests - work with any Heap implementation
+// ============================================================================
+
+/// Generate base Heap tests for a heap type using a module
+macro_rules! base_heap_tests {
+    ($mod_name:ident, $heap_type:ty) => {
+        mod $mod_name {
+            use super::*;
+
+            #[test]
+            fn test_empty_heap() {
+                let mut heap = <$heap_type>::new();
+                assert!(heap.is_empty());
+                assert_eq!(heap.len(), 0);
+                assert_eq!(heap.peek(), None);
+                assert_eq!(heap.pop(), None);
+            }
+
+            #[test]
+            fn test_basic_operations() {
+                let mut heap = <$heap_type>::new();
+                heap.push(5, "five");
+                heap.push(1, "one");
+                heap.push(10, "ten");
+                heap.push(3, "three");
+
+                assert!(!heap.is_empty());
+                assert_eq!(heap.len(), 4);
+                assert_eq!(heap.peek(), Some((&1, &"one")));
+
+                assert_eq!(heap.pop(), Some((1, "one")));
+                assert_eq!(heap.pop(), Some((3, "three")));
+                assert_eq!(heap.pop(), Some((5, "five")));
+                assert_eq!(heap.pop(), Some((10, "ten")));
+                assert_eq!(heap.pop(), None);
+                assert!(heap.is_empty());
+            }
+
+            #[test]
+            fn test_merge_operations() {
+                let mut heap1 = <$heap_type>::new();
+                heap1.push(5, "five");
+                heap1.push(1, "one");
+
+                let mut heap2 = <$heap_type>::new();
+                heap2.push(10, "ten");
+                heap2.push(3, "three");
+
+                heap1.merge(heap2);
+
+                assert_eq!(heap1.len(), 4);
+                assert_eq!(heap1.peek(), Some((&1, &"one")));
+                assert_eq!(heap1.pop(), Some((1, "one")));
+                assert_eq!(heap1.pop(), Some((3, "three")));
+                assert_eq!(heap1.pop(), Some((5, "five")));
+                assert_eq!(heap1.pop(), Some((10, "ten")));
+            }
+
+            #[test]
+            fn test_merge_empty() {
+                let mut heap1 = <$heap_type>::new();
+                heap1.push(5, "a");
+                heap1.push(1, "b");
+
+                let heap2 = <$heap_type>::new();
+                let len_before = heap1.len();
+                heap1.merge(heap2);
+                assert_eq!(heap1.len(), len_before);
+
+                let mut heap3 = <$heap_type>::new();
+                let mut heap4 = <$heap_type>::new();
+                heap4.push(3, "c");
+                heap3.merge(heap4);
+                assert_eq!(heap3.len(), 1);
+                assert_eq!(heap3.peek(), Some((&3, &"c")));
+            }
+
+            #[test]
+            fn test_duplicate_priorities() {
+                let mut heap = <$heap_type>::new();
+                heap.push(5, "a");
+                heap.push(5, "b");
+                heap.push(5, "c");
+                heap.push(1, "d");
+
+                assert_eq!(heap.pop(), Some((1, "d")));
+
+                let mut seen = std::collections::HashSet::new();
+                for _ in 0..3 {
+                    if let Some((pri, item)) = heap.pop() {
+                        assert_eq!(pri, 5);
+                        assert!(seen.insert(item));
+                    }
+                }
+                assert_eq!(seen.len(), 3);
+            }
+
+            #[test]
+            fn test_peek_idempotent() {
+                let mut heap = <$heap_type>::new();
+                heap.push(5, "five");
+                heap.push(1, "one");
+
+                assert_eq!(heap.peek(), Some((&1, &"one")));
+                assert_eq!(heap.peek(), Some((&1, &"one")));
+                assert_eq!(heap.peek(), Some((&1, &"one")));
+                assert_eq!(heap.len(), 2);
+                assert_eq!(heap.pop(), Some((1, "one")));
+            }
+
+            #[test]
+            fn test_merge_then_operations() {
+                let mut heap1 = <$heap_type>::new();
+                for i in 0..10 {
+                    heap1.push(i * 10, &"a");
+                }
+
+                let mut heap2 = <$heap_type>::new();
+                for i in 10..20 {
+                    heap2.push(i * 10, &"b");
+                }
+
+                heap1.merge(heap2);
+
+                let mut count = 0;
+                let mut last_priority = i32::MIN;
+                while let Some((priority, _)) = heap1.pop() {
+                    assert!(priority >= last_priority);
+                    last_priority = priority;
+                    count += 1;
+                }
+                assert_eq!(count, 20);
+            }
+
+            #[test]
+            fn test_rapid_operations() {
+                let mut heap = <$heap_type>::new();
+
+                for i in 0..50 {
+                    heap.push(i, &"x");
+                    if i % 3 == 0 {
+                        heap.pop();
+                    }
+                }
+
+                assert!(!heap.is_empty());
+                let mut count = 0;
+                while heap.pop().is_some() {
+                    count += 1;
+                }
+                assert!(count > 0);
+            }
+
+            #[test]
+            fn test_large_priorities() {
+                let mut heap = <$heap_type>::new();
+
+                heap.push(1_000_000_000, "a");
+                heap.push(1_500_000_000, "b");
+                heap.push(-1_000_000_000, "c");
+
+                assert_eq!(heap.peek(), Some((&-1_000_000_000, &"c")));
+                assert_eq!(heap.pop(), Some((-1_000_000_000, "c")));
+                assert_eq!(heap.pop(), Some((1_000_000_000, "a")));
+                assert_eq!(heap.pop(), Some((1_500_000_000, "b")));
+            }
+
+            #[test]
+            fn test_ascending_insertion() {
+                let mut heap = <$heap_type>::new();
+                for i in 0..50 {
+                    heap.push(i, &"x");
+                }
+                for i in 0..50 {
+                    let (pri, _) = heap.pop().unwrap();
+                    assert_eq!(pri, i);
+                }
+            }
+
+            #[test]
+            fn test_descending_insertion() {
+                let mut heap = <$heap_type>::new();
+                for i in (0..50).rev() {
+                    heap.push(i, &"x");
+                }
+                for i in 0..50 {
+                    let (pri, _) = heap.pop().unwrap();
+                    assert_eq!(pri, i);
+                }
+            }
+
+            #[test]
+            fn test_random_order_insertion() {
+                let mut heap = <$heap_type>::new();
+                let mut values: Vec<i32> = (0..100).collect();
+                for i in (0..values.len()).step_by(7) {
+                    if i + 1 < values.len() {
+                        values.swap(i, i + 1);
+                    }
+                }
+
+                for &val in &values {
+                    heap.push(val * 2, &"x");
+                }
+
+                for i in 0..100 {
+                    let (pri, _) = heap.pop().unwrap();
+                    assert_eq!(pri, i * 2);
+                }
+            }
+
+            #[test]
+            fn test_alternating_operations() {
+                let mut heap = <$heap_type>::new();
+
+                for i in 0..10 {
+                    heap.push(i * 10, &"x");
+                }
+
+                heap.pop();
+                heap.pop();
+                heap.pop();
+
+                for i in 10..15 {
+                    heap.push(i * 10, &"x");
+                }
+
+                heap.pop();
+                heap.pop();
+
+                assert!(!heap.is_empty());
+                assert!(heap.peek().is_some());
+
+                let mut count = 0;
+                while heap.pop().is_some() {
+                    count += 1;
+                }
+                assert_eq!(count, 10);
+            }
+
+            #[test]
+            fn test_merge_large() {
+                let mut heap1 = <$heap_type>::new();
+                for i in 0..100 {
+                    heap1.push(i * 2, &"a");
+                }
+
+                let mut heap2 = <$heap_type>::new();
+                for i in 100..200 {
+                    heap2.push(i * 2, &"b");
+                }
+
+                heap1.merge(heap2);
+                assert_eq!(heap1.len(), 200);
+
+                let mut last = i32::MIN;
+                let mut count = 0;
+                while let Some((priority, _)) = heap1.pop() {
+                    assert!(priority >= last);
+                    last = priority;
+                    count += 1;
+                }
+                assert_eq!(count, 200);
+            }
+
+            #[test]
+            fn test_negative_priorities() {
+                let mut heap = <$heap_type>::new();
+
+                heap.push(-10, "a");
+                heap.push(10, "b");
+                heap.push(-5, "c");
+                heap.push(5, "d");
+
+                assert_eq!(heap.pop(), Some((-10, "a")));
+                assert_eq!(heap.pop(), Some((-5, "c")));
+                assert_eq!(heap.pop(), Some((5, "d")));
+                assert_eq!(heap.pop(), Some((10, "b")));
+            }
+
+            #[test]
+            fn test_alias_methods() {
+                let mut heap = <$heap_type>::new();
+                heap.push(5, "five");
+                assert_eq!(heap.len(), 1);
+                assert_eq!(heap.peek(), Some((&5, &"five")));
+                assert_eq!(heap.pop(), Some((5, "five")));
+                assert_eq!(heap.pop(), None);
+            }
+
+            #[test]
+            fn test_string_items() {
+                let mut heap = <$heap_type>::new();
+
+                heap.push(3, "c");
+                heap.push(1, "a");
+                heap.push(2, "b");
+
+                assert_eq!(heap.peek().unwrap().1, &"a");
+                assert_eq!(heap.pop().unwrap().1, "a");
+                assert_eq!(heap.pop().unwrap().1, "b");
+                assert_eq!(heap.pop().unwrap().1, "c");
+            }
         }
     };
 }
 
-// Macro to generate all 30 tests for a heap type
-// Takes heap name, heap type, and all 30 test function names
-// This reduces repetition while being explicit about test names
-macro_rules! define_heap_tests {
-    (
-        $heap_name:ident,
-        $heap_type:ident,
-        $test_empty:ident, $test_basic:ident, $test_decrease_key:ident,
-        $test_multiple_decrease_keys:ident, $test_merge:ident, $test_merge_empty:ident,
-        $test_duplicate_priorities:ident, $test_stress:ident, $test_peek_idempotent:ident,
-        $test_single_element:ident, $test_merge_then_operations:ident, $test_rapid_operations:ident,
-        $test_large_priorities:ident, $test_decrease_key_same:ident, $test_complex_sequence:ident,
-        $test_ascending_insertion:ident, $test_descending_insertion:ident, $test_random_order_insertion:ident,
-        $test_multiple_decrease_same:ident, $test_decrease_key_new_min:ident, $test_alternating_operations:ident,
-        $test_merge_large:ident, $test_decrease_key_selective:ident, $test_all_same_priority:ident,
-        $test_negative_priorities:ident, $test_decrease_to_negative:ident, $test_alias_methods:ident,
-        $test_heap_property:ident, $test_merge_with_handles:ident, $test_very_large_sequence:ident,
-        $test_string_items:ident, $test_tuple_items:ident
-    ) => {
-        heap_test!($test_empty, $heap_type<String, i32>, test_empty_heap);
-        heap_test!($test_basic, $heap_type<&'static str, i32>, test_basic_operations);
-        heap_test!($test_decrease_key, $heap_type<i32, i32>, test_decrease_key_operations);
-        heap_test!($test_multiple_decrease_keys, $heap_type<i32, i32>, test_multiple_decrease_keys);
-        heap_test!($test_merge, $heap_type<&'static str, i32>, test_merge_operations);
-        heap_test!($test_merge_empty, $heap_type<i32, i32>, test_merge_empty);
-        heap_test!($test_duplicate_priorities, $heap_type<&'static str, i32>, test_duplicate_priorities);
-        heap_test!($test_stress, $heap_type<i32, i32>, test_stress_operations);
-        heap_test!($test_peek_idempotent, $heap_type<&'static str, i32>, test_peek_idempotent);
-        heap_test!($test_single_element, $heap_type<&'static str, i32>, test_single_element);
-        heap_test!($test_merge_then_operations, $heap_type<i32, i32>, test_merge_then_operations);
-        heap_test!($test_rapid_operations, $heap_type<i32, i32>, test_rapid_operations);
-        heap_test!($test_large_priorities, $heap_type<i32, i64>, test_large_priorities);
-        heap_test!($test_decrease_key_same, $heap_type<i32, i32>, test_decrease_key_same);
-        heap_test!($test_complex_sequence, $heap_type<String, i32>, test_complex_sequence);
-        heap_test!($test_ascending_insertion, $heap_type<i32, i32>, test_ascending_insertion);
-        heap_test!($test_descending_insertion, $heap_type<i32, i32>, test_descending_insertion);
-        heap_test!($test_random_order_insertion, $heap_type<i32, i32>, test_random_order_insertion);
-        heap_test!($test_multiple_decrease_same, $heap_type<i32, i32>, test_multiple_decrease_same);
-        heap_test!($test_decrease_key_new_min, $heap_type<i32, i32>, test_decrease_key_new_min);
-        heap_test!($test_alternating_operations, $heap_type<i32, i32>, test_alternating_operations);
-        heap_test!($test_merge_large, $heap_type<i32, i32>, test_merge_large);
-        heap_test!($test_decrease_key_selective, $heap_type<i32, i32>, test_decrease_key_selective);
-        heap_test!($test_all_same_priority, $heap_type<i32, i32>, test_all_same_priority);
-        heap_test!($test_negative_priorities, $heap_type<i32, i32>, test_negative_priorities);
-        heap_test!($test_decrease_to_negative, $heap_type<i32, i32>, test_decrease_to_negative);
-        heap_test!($test_alias_methods, $heap_type<&'static str, i32>, test_alias_methods);
-        heap_test!($test_heap_property, $heap_type<i32, i32>, test_heap_property);
-        heap_test!($test_merge_with_handles, $heap_type<i32, i32>, test_merge_with_handles);
-        heap_test!($test_very_large_sequence, $heap_type<i32, i32>, test_very_large_sequence);
-        heap_test!($test_string_items, $heap_type<String, i32>, test_string_items);
-        heap_test!($test_tuple_items, $heap_type<(i32, i32), i32>, test_tuple_items);
+/// Generate DecreaseKeyHeap tests for a heap type
+macro_rules! decrease_key_heap_tests {
+    ($mod_name:ident, $heap_type:ty) => {
+        mod $mod_name {
+            use super::*;
+
+            #[test]
+            fn test_decrease_key_operations() {
+                let mut heap = <$heap_type>::new();
+
+                let _h1 = heap.push_with_handle(100, 1);
+                let h2 = heap.push_with_handle(200, 2);
+                let _h3 = heap.push_with_handle(300, 3);
+                let h4 = heap.push_with_handle(400, 4);
+
+                assert_eq!(heap.peek(), Some((&100, &1)));
+
+                assert!(heap.decrease_key(&h2, 50).is_ok());
+                assert_eq!(heap.peek(), Some((&50, &2)));
+
+                assert!(heap.decrease_key(&h4, 25).is_ok());
+                assert_eq!(heap.peek(), Some((&25, &4)));
+
+                assert!(heap.decrease_key(&h4, 1).is_ok());
+                assert_eq!(heap.peek(), Some((&1, &4)));
+
+                assert_eq!(heap.pop(), Some((1, 4)));
+                assert_eq!(heap.pop(), Some((50, 2)));
+                assert_eq!(heap.pop(), Some((100, 1)));
+                assert_eq!(heap.pop(), Some((300, 3)));
+            }
+
+            #[test]
+            fn test_multiple_decrease_keys() {
+                let mut heap = <$heap_type>::new();
+                let mut handles = Vec::new();
+
+                for i in 0..20 {
+                    handles.push(heap.push_with_handle((i + 1) * 100, i));
+                }
+
+                for (i, handle) in handles.iter().enumerate() {
+                    assert!(heap.decrease_key(handle, i as i32).is_ok());
+                }
+
+                assert_eq!(heap.peek(), Some((&0, &0)));
+
+                for i in 0..20 {
+                    assert_eq!(heap.pop(), Some((i, i)));
+                }
+                assert!(heap.is_empty());
+            }
+
+            #[test]
+            fn test_stress_operations() {
+                let mut heap = <$heap_type>::new();
+                let mut handles = Vec::new();
+
+                for i in 0..100 {
+                    handles.push(heap.push_with_handle(i * 2, i));
+                }
+
+                for i in (0..100).step_by(3) {
+                    assert!(heap.decrease_key(&handles[i], i as i32 * 2 - 1).is_ok());
+                }
+
+                for _ in 0..20 {
+                    heap.pop();
+                }
+
+                assert!(!heap.is_empty());
+                assert!(heap.peek().is_some());
+
+                let mut count = 0;
+                while heap.pop().is_some() {
+                    count += 1;
+                }
+                assert_eq!(count, 80);
+            }
+
+            #[test]
+            fn test_single_element_decrease() {
+                let mut heap = <$heap_type>::new();
+                let handle = heap.push_with_handle(42, 99);
+
+                assert_eq!(heap.len(), 1);
+                assert_eq!(heap.peek(), Some((&42, &99)));
+
+                assert!(heap.decrease_key(&handle, 10).is_ok());
+                assert_eq!(heap.peek(), Some((&10, &99)));
+
+                assert_eq!(heap.pop(), Some((10, 99)));
+                assert!(heap.is_empty());
+            }
+
+            #[test]
+            fn test_decrease_key_same() {
+                let mut heap = <$heap_type>::new();
+                let handle = heap.push_with_handle(10, 1);
+
+                assert_eq!(
+                    heap.decrease_key(&handle, 10),
+                    Err(HeapError::PriorityNotDecreased)
+                );
+
+                assert_eq!(heap.peek(), Some((&10, &1)));
+            }
+
+            #[test]
+            fn test_complex_sequence() {
+                let mut heap = <$heap_type>::new();
+                let mut handles = Vec::new();
+
+                for i in 0..20 {
+                    if i % 2 == 0 {
+                        handles.push(heap.push_with_handle(i * 10, i + 1000));
+                    }
+                }
+
+                for (i, handle) in handles.iter().enumerate().skip(3).step_by(3) {
+                    let new_priority = (i as i32 * 5).max(1);
+                    if new_priority < i as i32 * 10 {
+                        assert!(heap.decrease_key(handle, new_priority).is_ok());
+                    }
+                }
+
+                for _ in 0..3 {
+                    if heap.pop().is_none() {
+                        break;
+                    }
+                }
+
+                for i in 20..25 {
+                    heap.push(i * 10, i + 2000);
+                }
+
+                assert!(!heap.is_empty());
+                assert!(heap.peek().is_some());
+
+                let mut count = 0;
+                while heap.pop().is_some() {
+                    count += 1;
+                    if count > 50 {
+                        break;
+                    }
+                }
+
+                assert!(heap.is_empty() || heap.peek().is_some());
+            }
+
+            #[test]
+            fn test_multiple_decrease_same() {
+                let mut heap = <$heap_type>::new();
+                let handle = heap.push_with_handle(1000, 1);
+
+                assert!(heap.decrease_key(&handle, 500).is_ok());
+                assert_eq!(heap.peek(), Some((&500, &1)));
+
+                assert!(heap.decrease_key(&handle, 250).is_ok());
+                assert_eq!(heap.peek(), Some((&250, &1)));
+
+                assert!(heap.decrease_key(&handle, 100).is_ok());
+                assert_eq!(heap.peek(), Some((&100, &1)));
+
+                assert!(heap.decrease_key(&handle, 50).is_ok());
+                assert_eq!(heap.peek(), Some((&50, &1)));
+
+                assert!(heap.decrease_key(&handle, 1).is_ok());
+                assert_eq!(heap.peek(), Some((&1, &1)));
+            }
+
+            #[test]
+            fn test_decrease_key_new_min() {
+                let mut heap = <$heap_type>::new();
+                let h1 = heap.push_with_handle(100, 1);
+                let h2 = heap.push_with_handle(200, 2);
+                let h3 = heap.push_with_handle(300, 3);
+
+                assert!(heap.decrease_key(&h3, 150).is_ok());
+                assert_eq!(heap.peek(), Some((&100, &1)));
+
+                assert!(heap.decrease_key(&h2, 50).is_ok());
+                assert_eq!(heap.peek(), Some((&50, &2)));
+
+                assert!(heap.decrease_key(&h1, 25).is_ok());
+                assert_eq!(heap.peek(), Some((&25, &1)));
+            }
+
+            #[test]
+            fn test_decrease_key_selective() {
+                let mut heap = <$heap_type>::new();
+                let mut handles = Vec::new();
+
+                for i in 0..30 {
+                    handles.push(heap.push_with_handle((i + 1) * 100, i));
+                }
+
+                for (i, handle) in handles.iter().enumerate() {
+                    if i % 2 == 0 {
+                        assert!(heap.decrease_key(handle, i as i32 * 10).is_ok());
+                    }
+                }
+
+                let min = heap.peek();
+                assert!(min.is_some());
+                assert!(*min.unwrap().0 < 100);
+
+                let mut last = i32::MIN;
+                while let Some((priority, _)) = heap.pop() {
+                    assert!(priority >= last);
+                    last = priority;
+                }
+            }
+
+            #[test]
+            fn test_all_same_priority() {
+                let mut heap = <$heap_type>::new();
+                let mut handles = Vec::new();
+
+                for i in 0..10 {
+                    handles.push(heap.push_with_handle((i + 1) * 10, i));
+                }
+
+                for handle in &handles {
+                    assert!(heap.decrease_key(handle, 5).is_ok());
+                }
+
+                assert_eq!(heap.peek().unwrap().0, &5);
+
+                let mut seen = std::collections::HashSet::new();
+                while let Some((priority, item)) = heap.pop() {
+                    assert_eq!(priority, 5);
+                    assert!(seen.insert(item));
+                }
+                assert_eq!(seen.len(), 10);
+            }
+
+            #[test]
+            fn test_decrease_to_negative() {
+                let mut heap = <$heap_type>::new();
+                let h1 = heap.push_with_handle(10, 1);
+                let _h2 = heap.push_with_handle(20, 2);
+
+                assert!(heap.decrease_key(&h1, -5).is_ok());
+                assert_eq!(heap.peek(), Some((&-5, &1)));
+                assert_eq!(heap.pop(), Some((-5, 1)));
+            }
+
+            #[test]
+            fn test_heap_property() {
+                let mut heap = <$heap_type>::new();
+                let mut handles = Vec::new();
+
+                for i in 0..50 {
+                    handles.push(heap.push_with_handle((i * 17 + 23) % 1000, i));
+                }
+
+                for i in (0..50).step_by(7) {
+                    if let Some(handle) = handles.get(i) {
+                        let current_min = heap.peek().unwrap().0;
+                        let new_priority = (*current_min / 2).max(1);
+                        assert!(heap.decrease_key(handle, new_priority).is_ok());
+                    }
+                }
+
+                let mut last_priority = i32::MIN;
+                while let Some((priority, _)) = heap.pop() {
+                    assert!(priority >= last_priority);
+                    last_priority = priority;
+                }
+            }
+
+            #[test]
+            fn test_merge_with_handles() {
+                let mut heap1 = <$heap_type>::new();
+                let h1 = heap1.push_with_handle(100, 1);
+
+                let mut heap2 = <$heap_type>::new();
+                let h2 = heap2.push_with_handle(200, 2);
+
+                heap1.merge(heap2);
+
+                assert!(heap1.decrease_key(&h1, 50).is_ok());
+                assert_eq!(heap1.peek(), Some((&50, &1)));
+
+                assert!(heap1.decrease_key(&h2, 25).is_ok());
+                assert_eq!(heap1.peek(), Some((&25, &2)));
+            }
+
+            #[test]
+            fn test_very_large_sequence() {
+                let mut heap = <$heap_type>::new();
+                let mut handles = Vec::new();
+
+                for i in 0..1000 {
+                    handles.push(heap.push_with_handle(i * 10, i));
+                }
+
+                for i in (0..1000).step_by(10) {
+                    assert!(heap.decrease_key(&handles[i], (i as i32) - 1).is_ok());
+                }
+
+                for _ in 0..100 {
+                    heap.pop();
+                }
+
+                for i in 1000..1200 {
+                    heap.push(i * 10, i);
+                }
+
+                assert!(!heap.is_empty());
+
+                let mut count = 0;
+                while heap.pop().is_some() {
+                    count += 1;
+                }
+                assert_eq!(count, 1100);
+            }
+        }
     };
 }
 
-// Generate tests for each heap type with explicit test names
-define_heap_tests!(
-    fibonacci,
-    FibonacciHeap,
-    test_fibonacci_empty,
-    test_fibonacci_basic,
-    test_fibonacci_decrease_key,
-    test_fibonacci_multiple_decrease_keys,
-    test_fibonacci_merge,
-    test_fibonacci_merge_empty,
-    test_fibonacci_duplicate_priorities,
-    test_fibonacci_stress,
-    test_fibonacci_peek_idempotent,
-    test_fibonacci_single_element,
-    test_fibonacci_merge_then_operations,
-    test_fibonacci_rapid_operations,
-    test_fibonacci_large_priorities,
-    test_fibonacci_decrease_key_same,
-    test_fibonacci_complex_sequence,
-    test_fibonacci_ascending_insertion,
-    test_fibonacci_descending_insertion,
-    test_fibonacci_random_order_insertion,
-    test_fibonacci_multiple_decrease_same,
-    test_fibonacci_decrease_key_new_min,
-    test_fibonacci_alternating_operations,
-    test_fibonacci_merge_large,
-    test_fibonacci_decrease_key_selective,
-    test_fibonacci_all_same_priority,
-    test_fibonacci_negative_priorities,
-    test_fibonacci_decrease_to_negative,
-    test_fibonacci_alias_methods,
-    test_fibonacci_heap_property,
-    test_fibonacci_merge_with_handles,
-    test_fibonacci_very_large_sequence,
-    test_fibonacci_string_items,
-    test_fibonacci_tuple_items
+// ============================================================================
+// Generate tests for all heap implementations
+// ============================================================================
+
+// SimpleBinaryHeap - base Heap only (no decrease_key)
+base_heap_tests!(
+    simple_binary_base,
+    rust_advanced_heaps::simple_binary::SimpleBinaryHeap<&'static str, i32>
 );
 
-define_heap_tests!(
-    pairing,
-    PairingHeap,
-    test_pairing_empty,
-    test_pairing_basic,
-    test_pairing_decrease_key,
-    test_pairing_multiple_decrease_keys,
-    test_pairing_merge,
-    test_pairing_merge_empty,
-    test_pairing_duplicate_priorities,
-    test_pairing_stress,
-    test_pairing_peek_idempotent,
-    test_pairing_single_element,
-    test_pairing_merge_then_operations,
-    test_pairing_rapid_operations,
-    test_pairing_large_priorities,
-    test_pairing_decrease_key_same,
-    test_pairing_complex_sequence,
-    test_pairing_ascending_insertion,
-    test_pairing_descending_insertion,
-    test_pairing_random_order_insertion,
-    test_pairing_multiple_decrease_same,
-    test_pairing_decrease_key_new_min,
-    test_pairing_alternating_operations,
-    test_pairing_merge_large,
-    test_pairing_decrease_key_selective,
-    test_pairing_all_same_priority,
-    test_pairing_negative_priorities,
-    test_pairing_decrease_to_negative,
-    test_pairing_alias_methods,
-    test_pairing_heap_property,
-    test_pairing_merge_with_handles,
-    test_pairing_very_large_sequence,
-    test_pairing_string_items,
-    test_pairing_tuple_items
+// Fibonacci Heap
+base_heap_tests!(
+    fibonacci_base,
+    rust_advanced_heaps::fibonacci::FibonacciHeap<&'static str, i32>
 );
+decrease_key_heap_tests!(fibonacci_decrease, rust_advanced_heaps::fibonacci::FibonacciHeap<i32, i32>);
 
-define_heap_tests!(
-    rank_pairing,
-    RankPairingHeap,
-    test_rank_pairing_empty,
-    test_rank_pairing_basic,
-    test_rank_pairing_decrease_key,
-    test_rank_pairing_multiple_decrease_keys,
-    test_rank_pairing_merge,
-    test_rank_pairing_merge_empty,
-    test_rank_pairing_duplicate_priorities,
-    test_rank_pairing_stress,
-    test_rank_pairing_peek_idempotent,
-    test_rank_pairing_single_element,
-    test_rank_pairing_merge_then_operations,
-    test_rank_pairing_rapid_operations,
-    test_rank_pairing_large_priorities,
-    test_rank_pairing_decrease_key_same,
-    test_rank_pairing_complex_sequence,
-    test_rank_pairing_ascending_insertion,
-    test_rank_pairing_descending_insertion,
-    test_rank_pairing_random_order_insertion,
-    test_rank_pairing_multiple_decrease_same,
-    test_rank_pairing_decrease_key_new_min,
-    test_rank_pairing_alternating_operations,
-    test_rank_pairing_merge_large,
-    test_rank_pairing_decrease_key_selective,
-    test_rank_pairing_all_same_priority,
-    test_rank_pairing_negative_priorities,
-    test_rank_pairing_decrease_to_negative,
-    test_rank_pairing_alias_methods,
-    test_rank_pairing_heap_property,
-    test_rank_pairing_merge_with_handles,
-    test_rank_pairing_very_large_sequence,
-    test_rank_pairing_string_items,
-    test_rank_pairing_tuple_items
+// Pairing Heap
+base_heap_tests!(
+    pairing_base,
+    rust_advanced_heaps::pairing::PairingHeap<&'static str, i32>
 );
+decrease_key_heap_tests!(pairing_decrease, rust_advanced_heaps::pairing::PairingHeap<i32, i32>);
 
-define_heap_tests!(
-    binomial,
-    BinomialHeap,
-    test_binomial_empty,
-    test_binomial_basic,
-    test_binomial_decrease_key,
-    test_binomial_multiple_decrease_keys,
-    test_binomial_merge,
-    test_binomial_merge_empty,
-    test_binomial_duplicate_priorities,
-    test_binomial_stress,
-    test_binomial_peek_idempotent,
-    test_binomial_single_element,
-    test_binomial_merge_then_operations,
-    test_binomial_rapid_operations,
-    test_binomial_large_priorities,
-    test_binomial_decrease_key_same,
-    test_binomial_complex_sequence,
-    test_binomial_ascending_insertion,
-    test_binomial_descending_insertion,
-    test_binomial_random_order_insertion,
-    test_binomial_multiple_decrease_same,
-    test_binomial_decrease_key_new_min,
-    test_binomial_alternating_operations,
-    test_binomial_merge_large,
-    test_binomial_decrease_key_selective,
-    test_binomial_all_same_priority,
-    test_binomial_negative_priorities,
-    test_binomial_decrease_to_negative,
-    test_binomial_alias_methods,
-    test_binomial_heap_property,
-    test_binomial_merge_with_handles,
-    test_binomial_very_large_sequence,
-    test_binomial_string_items,
-    test_binomial_tuple_items
+// Binomial Heap
+base_heap_tests!(
+    binomial_base,
+    rust_advanced_heaps::binomial::BinomialHeap<&'static str, i32>
 );
+decrease_key_heap_tests!(binomial_decrease, rust_advanced_heaps::binomial::BinomialHeap<i32, i32>);
 
-define_heap_tests!(
-    strict_fibonacci,
-    StrictFibonacciHeap,
-    test_strict_fibonacci_empty,
-    test_strict_fibonacci_basic,
-    test_strict_fibonacci_decrease_key,
-    test_strict_fibonacci_multiple_decrease_keys,
-    test_strict_fibonacci_merge,
-    test_strict_fibonacci_merge_empty,
-    test_strict_fibonacci_duplicate_priorities,
-    test_strict_fibonacci_stress,
-    test_strict_fibonacci_peek_idempotent,
-    test_strict_fibonacci_single_element,
-    test_strict_fibonacci_merge_then_operations,
-    test_strict_fibonacci_rapid_operations,
-    test_strict_fibonacci_large_priorities,
-    test_strict_fibonacci_decrease_key_same,
-    test_strict_fibonacci_complex_sequence,
-    test_strict_fibonacci_ascending_insertion,
-    test_strict_fibonacci_descending_insertion,
-    test_strict_fibonacci_random_order_insertion,
-    test_strict_fibonacci_multiple_decrease_same,
-    test_strict_fibonacci_decrease_key_new_min,
-    test_strict_fibonacci_alternating_operations,
-    test_strict_fibonacci_merge_large,
-    test_strict_fibonacci_decrease_key_selective,
-    test_strict_fibonacci_all_same_priority,
-    test_strict_fibonacci_negative_priorities,
-    test_strict_fibonacci_decrease_to_negative,
-    test_strict_fibonacci_alias_methods,
-    test_strict_fibonacci_heap_property,
-    test_strict_fibonacci_merge_with_handles,
-    test_strict_fibonacci_very_large_sequence,
-    test_strict_fibonacci_string_items,
-    test_strict_fibonacci_tuple_items
+// Rank-Pairing Heap
+base_heap_tests!(
+    rank_pairing_base,
+    rust_advanced_heaps::rank_pairing::RankPairingHeap<&'static str, i32>
 );
+decrease_key_heap_tests!(rank_pairing_decrease, rust_advanced_heaps::rank_pairing::RankPairingHeap<i32, i32>);
 
-define_heap_tests!(
-    twothree,
-    TwoThreeHeap,
-    test_twothree_empty,
-    test_twothree_basic,
-    test_twothree_decrease_key,
-    test_twothree_multiple_decrease_keys,
-    test_twothree_merge,
-    test_twothree_merge_empty,
-    test_twothree_duplicate_priorities,
-    test_twothree_stress,
-    test_twothree_peek_idempotent,
-    test_twothree_single_element,
-    test_twothree_merge_then_operations,
-    test_twothree_rapid_operations,
-    test_twothree_large_priorities,
-    test_twothree_decrease_key_same,
-    test_twothree_complex_sequence,
-    test_twothree_ascending_insertion,
-    test_twothree_descending_insertion,
-    test_twothree_random_order_insertion,
-    test_twothree_multiple_decrease_same,
-    test_twothree_decrease_key_new_min,
-    test_twothree_alternating_operations,
-    test_twothree_merge_large,
-    test_twothree_decrease_key_selective,
-    test_twothree_all_same_priority,
-    test_twothree_negative_priorities,
-    test_twothree_decrease_to_negative,
-    test_twothree_alias_methods,
-    test_twothree_heap_property,
-    test_twothree_merge_with_handles,
-    test_twothree_very_large_sequence,
-    test_twothree_string_items,
-    test_twothree_tuple_items
+// Strict Fibonacci Heap
+base_heap_tests!(
+    strict_fibonacci_base,
+    rust_advanced_heaps::strict_fibonacci::StrictFibonacciHeap<&'static str, i32>
 );
+decrease_key_heap_tests!(strict_fibonacci_decrease, rust_advanced_heaps::strict_fibonacci::StrictFibonacciHeap<i32, i32>);
 
-define_heap_tests!(
-    skew_binomial,
-    SkewBinomialHeap,
-    test_skew_binomial_empty,
-    test_skew_binomial_basic,
-    test_skew_binomial_decrease_key,
-    test_skew_binomial_multiple_decrease_keys,
-    test_skew_binomial_merge,
-    test_skew_binomial_merge_empty,
-    test_skew_binomial_duplicate_priorities,
-    test_skew_binomial_stress,
-    test_skew_binomial_peek_idempotent,
-    test_skew_binomial_single_element,
-    test_skew_binomial_merge_then_operations,
-    test_skew_binomial_rapid_operations,
-    test_skew_binomial_large_priorities,
-    test_skew_binomial_decrease_key_same,
-    test_skew_binomial_complex_sequence,
-    test_skew_binomial_ascending_insertion,
-    test_skew_binomial_descending_insertion,
-    test_skew_binomial_random_order_insertion,
-    test_skew_binomial_multiple_decrease_same,
-    test_skew_binomial_decrease_key_new_min,
-    test_skew_binomial_alternating_operations,
-    test_skew_binomial_merge_large,
-    test_skew_binomial_decrease_key_selective,
-    test_skew_binomial_all_same_priority,
-    test_skew_binomial_negative_priorities,
-    test_skew_binomial_decrease_to_negative,
-    test_skew_binomial_alias_methods,
-    test_skew_binomial_heap_property,
-    test_skew_binomial_merge_with_handles,
-    test_skew_binomial_very_large_sequence,
-    test_skew_binomial_string_items,
-    test_skew_binomial_tuple_items
+// 2-3 Heap
+base_heap_tests!(
+    twothree_base,
+    rust_advanced_heaps::twothree::TwoThreeHeap<&'static str, i32>
 );
+decrease_key_heap_tests!(twothree_decrease, rust_advanced_heaps::twothree::TwoThreeHeap<i32, i32>);
+
+// Skew Binomial Heap
+base_heap_tests!(
+    skew_binomial_base,
+    rust_advanced_heaps::skew_binomial::SkewBinomialHeap<&'static str, i32>
+);
+decrease_key_heap_tests!(skew_binomial_decrease, rust_advanced_heaps::skew_binomial::SkewBinomialHeap<i32, i32>);

--- a/tests/stress_tests.rs
+++ b/tests/stress_tests.rs
@@ -7,7 +7,7 @@ use rust_advanced_heaps::binomial::BinomialHeap;
 use rust_advanced_heaps::fibonacci::FibonacciHeap;
 use rust_advanced_heaps::pairing::PairingHeap;
 use rust_advanced_heaps::rank_pairing::RankPairingHeap;
-use rust_advanced_heaps::Heap;
+use rust_advanced_heaps::{DecreaseKeyHeap, Heap};
 
 /// Test massive numbers of inserts and pops
 fn test_massive_operations<H: Heap<i32, i32>>() {
@@ -30,13 +30,13 @@ fn test_massive_operations<H: Heap<i32, i32>>() {
 }
 
 /// Test many decrease_key operations
-fn test_many_decrease_keys<H: Heap<i32, i32>>() {
+fn test_many_decrease_keys<H: DecreaseKeyHeap<i32, i32>>() {
     let mut heap = H::new();
     let mut handles = Vec::new();
 
     // Insert elements with high priorities
     for i in 0..500 {
-        handles.push(heap.push(10000 + i, i));
+        handles.push(heap.push_with_handle(10000 + i, i));
     }
 
     // Decrease all keys
@@ -94,13 +94,13 @@ fn test_large_merge<H: Heap<i32, i32>>() {
 }
 
 /// Test decrease_key on already popped element (should handle gracefully)
-fn test_decrease_on_many_operations<H: Heap<i32, i32>>() {
+fn test_decrease_on_many_operations<H: DecreaseKeyHeap<i32, i32>>() {
     let mut heap = H::new();
     let mut handles = Vec::new();
 
     // Insert many elements
     for i in 0..300 {
-        handles.push(heap.push(i * 10, i));
+        handles.push(heap.push_with_handle(i * 10, i));
     }
 
     // Pop some
@@ -134,13 +134,13 @@ fn test_large_priorities<H: Heap<i32, i64>>() {
 }
 
 /// Test rapid-fire operations
-fn test_rapid_fire<H: Heap<i32, i32>>() {
+fn test_rapid_fire<H: DecreaseKeyHeap<i32, i32>>() {
     let mut heap = H::new();
     let mut handles = Vec::new();
 
     // Rapid insert
     for i in 0..200 {
-        handles.push(heap.push(i, i));
+        handles.push(heap.push_with_handle(i, i));
     }
 
     // Rapid decrease keys


### PR DESCRIPTION
## Summary

- Introduce a two-tier trait design separating base heap operations from `decrease_key` support:
  - `Heap`: Base trait for simple heaps (push, pop, peek, merge)
  - `DecreaseKeyHeap`: Extended trait adding `decrease_key` and handle-based operations
- Add `SimpleBinaryHeap` implementing only the base `Heap` trait
- Update `stdlib_compat` to use base `Heap` trait (no decrease_key needed)
- Refactor `generic_heap_tests` with module-based macros (no external crate dependencies)
- Add `SimpleBinaryHeap` to all documentation including REFERENCES.md with Williams 1964 citation

## Test plan

- [x] All 385 tests pass (`cargo test`)
- [x] Clippy clean (`cargo clippy --all-targets`)
- [x] Formatting clean (`cargo fmt --check`)
- [x] Doc tests pass (`cargo test --doc`)

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced two-tier trait design: base Heap trait for core operations and DecreaseKeyHeap trait for handle-based decrease-key functionality
  * Added `merge()` operation to combine heaps
  * Added `push_with_handle()` method for obtaining handles when needed
  * Implemented SimpleBinaryHeap as a new heap variant

* **Breaking Changes**
  * `push()` no longer returns a handle; handles obtained via `push_with_handle()` when using DecreaseKeyHeap
  * Handle functionality moved to DecreaseKeyHeap trait

* **Documentation**
  * Updated API documentation to reflect trait hierarchy and new usage patterns

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->