### PR TITLE
Phase 1: Refactor StrictFibonacciHeap to use intrusive circular lists

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ expensive_verify = []
 criterion = "0.5"
 # For stack-allocated vectors in fixed-arity heaps
 smallvec = "1.13"
+# For intrusive circular doubly-linked lists (used by strict Fibonacci heap)
+intrusive-circular-list = { path = "crates/intrusive-circular-list" }
 
 [dev-dependencies]
 proptest = "1.4"


### PR DESCRIPTION
## Summary

Phase 1 of the strict Fibonacci heap refactoring (Issue #42):

- Convert from `Rc<RefCell<Node>>` to raw pointers (`NonNull<Node>`) for better performance
- Use `CircularLink` from `intrusive-circular-list` subcrate for O(1) sibling operations
- Add `rank` field to Node (preparation for consolidation in future phases)
- Update all heap operations for the new Node structure:
  - `add_to_roots`, `remove_from_roots`, `splice_children_to_roots`
  - `consolidate`, `link`, `cut`
- Update documentation to be honest about current **amortized** bounds (not yet worst-case as in the Brodal-Lagogiannis-Tarjan paper)

Closes part of #42

## Changes

| File | Changes |
|------|---------|
| `Cargo.toml` | Add `intrusive-circular-list` dependency |
| `src/strict_fibonacci.rs` | Complete rewrite using raw pointers and intrusive circular lists |

## Current vs Target Complexity

| Operation | Current Bound | Target (Paper) |
|-----------|---------------|----------------|
| insert | O(1) amortized | O(1) worst-case |
| peek | O(1) worst-case | O(1) worst-case |
| pop | O(log n) amortized | O(log n) worst-case |
| decrease_key | O(1) amortized | O(1) worst-case |
| merge | O(1) amortized | O(1) worst-case |

## Test plan

- [x] All 8 unit tests pass
- [x] All 32 generic heap tests pass
- [x] All 11 property tests pass
- [x] All 3 big-o complexity tests pass
- [x] Clippy passes with no warnings

## Next Phases

- Phase 2: Rank record system
- Phase 3: Fix-list + reductions  
- Phase 4: Loss tracking
- Phase 5: delete_min integration

Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)