### PR TITLE
Phase 2: Add rank record infrastructure for strict Fibonacci heap

### DIFF
--- a/src/strict_fibonacci.rs
+++ b/src/strict_fibonacci.rs
@@ -305,6 +305,11 @@ impl<T, P> Node<T, P> {
 unsafe fn retire_rank_record(rank_ptr: NonNull<RankRecord>) {
     let rank = rank_ptr.as_ptr();
 
+    debug_assert!(
+        (*rank).reference_count == 0,
+        "Retiring rank record with non-zero reference_count"
+    );
+
     // Unlink from the doubly-linked list
     if let Some(mut prev_ptr) = (*rank).prev {
         prev_ptr.as_mut().next = (*rank).next;
@@ -920,6 +925,10 @@ impl<T, P: Ord> StrictFibonacciHeap<T, P> {
             ops.unlink(node_link);
 
             // Decrement parent's rank
+            debug_assert!(
+                (*parent).rank_count > 0,
+                "Parent rank_count underflow in cut()"
+            );
             (*parent).rank_count -= 1;
 
             // Clear parent link


### PR DESCRIPTION
## Summary

- Add `RankRecord` struct with doubly-linked list for O(1) rank-based access
- Implement reference counting for rank record lifecycle management
- Update `Node` with `rank_count` field and `rank_record` pointer
- Add `rank_list` field to `StrictFibonacciHeap`
- Add helper methods: `rank()`, `set_rank_record()`, `retire_rank_record()`

This is Phase 2 of implementing the Brodal-Lagogiannis-Tarjan strict Fibonacci heap algorithm per #42. The rank record infrastructure is now in place; actual integration with active/passive node tracking will come in later phases.

## Changes

The rank record system enables O(1) access to nodes by rank, which is essential for the reduction operations that maintain worst-case bounds:

- **RankRecord**: Doubly-linked list of records ordered by rank value, with reference counting
- **Node.rank()**: Returns rank from rank_record if present, otherwise from local `rank_count`
- **Node.set_rank_record()**: Updates rank record with proper reference count management
- **retire_rank_record()**: Deallocates rank records when reference count reaches zero

## Test plan

- [x] All 361 tests pass
- [x] Clippy passes with no warnings
- [x] Pre-commit hooks pass

## References

- Brodal, Lagogiannis, Tarjan (2012) "Strict Fibonacci Heaps"
- Reference Python implementation from paper authors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked internal rank-tracking into a linked record system for O(1) rank access patterns and safer lifecycle/deallocation.
  * Updated link/consolidation/cut flows to use the new rank-count semantics.
  * Improved memory management and stability during node retirement.
  * No changes to public APIs or exported signatures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->