### PR TITLE
fix(skew-binomial): replace unwrap_unchecked with expect in peek()

### DIFF
--- a/src/skew_binomial.rs
+++ b/src/skew_binomial.rs
@@ -123,8 +123,11 @@ impl<T, P: Ord> Heap<T, P> for SkewBinomialHeap<T, P> {
         self.min.as_ref().map(|min_ref| unsafe {
             let ptr = min_ref.as_ptr();
             (
-                (*ptr).priority.as_ref().unwrap_unchecked(),
-                (*ptr).item.as_ref().unwrap_unchecked(),
+                (*ptr)
+                    .priority
+                    .as_ref()
+                    .expect("min node must have priority"),
+                (*ptr).item.as_ref().expect("min node must have item"),
             )
         })
     }


### PR DESCRIPTION
## Summary

- Replace `unwrap_unchecked()` with `expect()` in `SkewBinomialHeap::peek()` to avoid undefined behavior if internal invariants are violated
- Invariant violations will now panic with clear error messages instead of causing UB

Fixes #41

## Test plan

- [x] All existing skew_binomial tests pass
- [x] Clippy passes with no warnings
- [x] Code formatting verified

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal code safety and error handling mechanisms for improved reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->